### PR TITLE
Make IPV6 really optional

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -37,15 +37,14 @@ module "complete_sg" {
 
   # Prefix list ids to use in all ingress rules in this module.
   # ingress_prefix_list_ids = ["pl-123456"]
-
   # Open for all CIDRs defined in ingress_cidr_blocks
   ingress_rules = ["https-443-tcp"]
+
   # Open to CIDRs blocks (rule or from_port+to_port+protocol+description)
   ingress_with_cidr_blocks = [
     {
-      rule             = "postgresql-tcp"
-      cidr_blocks      = "0.0.0.0/0,2.2.2.2/32"
-      ipv6_cidr_blocks = "2001:db8::/60"
+      rule        = "postgresql-tcp"
+      cidr_blocks = "0.0.0.0/0,2.2.2.2/32"
     },
     {
       rule        = "postgresql-tcp"
@@ -59,6 +58,18 @@ module "complete_sg" {
       cidr_blocks = "10.10.0.0/20"
     },
   ]
+
+  # Open to IPV6 CIDR blocks (rule or from_port+to_port+protocol+description)
+  ingress_with_ipv6_cidr_blocks = [
+    {
+      from_port        = 300
+      to_port          = 400
+      protocol         = "tcp"
+      description      = "Service ports (ipv6)"
+      ipv6_cidr_blocks = "2001:db8::/64"
+    },
+  ]
+
   # Open for security group id (rule or from_port+to_port+protocol+description)
   ingress_with_source_security_group_id = [
     {
@@ -73,6 +84,7 @@ module "complete_sg" {
       source_security_group_id = "${data.aws_security_group.default.id}"
     },
   ]
+
   # Open for self (rule or from_port+to_port+protocol+description)
   ingress_with_self = [
     {
@@ -92,25 +104,26 @@ module "complete_sg" {
       self      = false
     },
   ]
+
   # Default CIDR blocks, which will be used for all egress rules in this module. Typically these are CIDR blocks of the VPC.
   # If this is not specified then no CIDR blocks will be used.
   egress_cidr_blocks = ["10.10.0.0/16"]
+
   egress_ipv6_cidr_blocks = ["2001:db8::/64"]
 
   # Prefix list ids to use in all egress rules in this module.
   # egress_prefix_list_ids = ["pl-123456"]
-
   # Open for all CIDRs defined in egress_cidr_blocks
   egress_rules = ["http-80-tcp"]
+
   # Open to CIDRs blocks (rule or from_port+to_port+protocol+description)
   egress_with_cidr_blocks = [
     {
-      rule             = "postgresql-tcp"
-      cidr_blocks      = "0.0.0.0/0,2.2.2.2/32"
-      ipv6_cidr_blocks = "2001:db8::/60"
+      rule        = "postgresql-tcp"
+      cidr_blocks = "0.0.0.0/0,2.2.2.2/32"
     },
     {
-      rule        = "postgresql-tcp"
+      rule        = "https-443-tcp"
       cidr_blocks = "30.30.30.30/32"
     },
     {
@@ -121,6 +134,18 @@ module "complete_sg" {
       cidr_blocks = "10.10.0.0/20"
     },
   ]
+
+  # Open to IPV6 CIDR blocks (rule or from_port+to_port+protocol+description)
+  egress_with_ipv6_cidr_blocks = [
+    {
+      from_port        = 300
+      to_port          = 400
+      protocol         = "tcp"
+      description      = "Service ports (ipv6)"
+      ipv6_cidr_blocks = "2001:db8::/64"
+    },
+  ]
+
   # Open for security group id (rule or from_port+to_port+protocol+description)
   egress_with_source_security_group_id = [
     {
@@ -135,6 +160,7 @@ module "complete_sg" {
       source_security_group_id = "${data.aws_security_group.default.id}"
     },
   ]
+
   # Open for self (rule or from_port+to_port+protocol+description)
   egress_with_self = [
     {
@@ -152,6 +178,57 @@ module "complete_sg" {
       to_port   = 51
       protocol  = 6
       self      = false
+    },
+  ]
+}
+
+######################################################
+# Security group with IPv4 and IPv6 sets of arguments
+######################################################
+module "ipv4_ipv6_example" {
+  source = "../../"
+
+  name        = "ipv4-ipv6-example"
+  description = "IPv4 and IPv6 example"
+  vpc_id      = "${data.aws_vpc.default.id}"
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 8080
+      to_port     = 8090
+      protocol    = "tcp"
+      description = "User-service ports (ipv4)"
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+
+  ingress_with_ipv6_cidr_blocks = [
+    {
+      from_port        = 8080
+      to_port          = 8090
+      protocol         = "tcp"
+      description      = "User-service ports (ipv6)"
+      ipv6_cidr_blocks = "2001:db8::/64"
+    },
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      from_port   = 8090
+      to_port     = 8100
+      protocol    = "tcp"
+      description = "User-service ports (ipv4)"
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+
+  egress_with_ipv6_cidr_blocks = [
+    {
+      from_port        = 8090
+      to_port          = 8100
+      protocol         = "tcp"
+      description      = "User-service ports (ipv6)"
+      ipv6_cidr_blocks = "2001:db8::/64"
     },
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -47,20 +47,34 @@ resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
   protocol  = "${lookup(var.ingress_with_source_security_group_id[count.index], "protocol", element(var.rules[lookup(var.ingress_with_source_security_group_id[count.index], "rule", "_")], 2))}"
 }
 
-# Security group rules with "cidr_blocks", but without "source_security_group_id" and "self"
+# Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
   count = "${length(var.ingress_with_cidr_blocks)}"
 
   security_group_id = "${aws_security_group.this.id}"
   type              = "ingress"
 
-  cidr_blocks      = ["${split(",", lookup(var.ingress_with_cidr_blocks[count.index], "cidr_blocks", join(",", var.ingress_cidr_blocks)))}"]
-  ipv6_cidr_blocks = ["${split(",", lookup(var.ingress_with_cidr_blocks[count.index], "ipv6_cidr_blocks", join(",", var.ingress_ipv6_cidr_blocks)))}"]
-  prefix_list_ids  = ["${var.ingress_prefix_list_ids}"]
+  cidr_blocks     = ["${split(",", lookup(var.ingress_with_cidr_blocks[count.index], "cidr_blocks", join(",", var.ingress_cidr_blocks)))}"]
+  prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
   from_port = "${lookup(var.ingress_with_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")], 0))}"
   to_port   = "${lookup(var.ingress_with_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")], 1))}"
   protocol  = "${lookup(var.ingress_with_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")], 2))}"
+}
+
+# Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
+resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
+  count = "${length(var.ingress_with_ipv6_cidr_blocks)}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "ingress"
+
+  ipv6_cidr_blocks = ["${split(",", lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "ipv6_cidr_blocks", join(",", var.ingress_ipv6_cidr_blocks)))}"]
+  prefix_list_ids  = ["${var.ingress_prefix_list_ids}"]
+
+  from_port = "${lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 2))}"
 }
 
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
@@ -121,20 +135,34 @@ resource "aws_security_group_rule" "egress_with_source_security_group_id" {
   protocol  = "${lookup(var.egress_with_source_security_group_id[count.index], "protocol", element(var.rules[lookup(var.egress_with_source_security_group_id[count.index], "rule", "_")], 2))}"
 }
 
-# Security group rules with "cidr_blocks", but without "source_security_group_id" and "self"
+# Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "egress_with_cidr_blocks" {
   count = "${length(var.egress_with_cidr_blocks)}"
 
   security_group_id = "${aws_security_group.this.id}"
   type              = "egress"
 
-  cidr_blocks      = ["${split(",", lookup(var.egress_with_cidr_blocks[count.index], "cidr_blocks", join(",", var.egress_cidr_blocks)))}"]
-  ipv6_cidr_blocks = ["${split(",", lookup(var.egress_with_cidr_blocks[count.index], "ipv6_cidr_blocks", join(",", var.egress_ipv6_cidr_blocks)))}"]
-  prefix_list_ids  = ["${var.egress_prefix_list_ids}"]
+  cidr_blocks     = ["${split(",", lookup(var.egress_with_cidr_blocks[count.index], "cidr_blocks", join(",", var.egress_cidr_blocks)))}"]
+  prefix_list_ids = ["${var.egress_prefix_list_ids}"]
 
   from_port = "${lookup(var.egress_with_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")], 0))}"
   to_port   = "${lookup(var.egress_with_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")], 1))}"
   protocol  = "${lookup(var.egress_with_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")], 2))}"
+}
+
+# Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
+resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
+  count = "${length(var.egress_with_ipv6_cidr_blocks)}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "egress"
+
+  ipv6_cidr_blocks = ["${split(",", lookup(var.egress_with_ipv6_cidr_blocks[count.index], "ipv6_cidr_blocks", join(",", var.egress_ipv6_cidr_blocks)))}"]
+  prefix_list_ids  = ["${var.egress_prefix_list_ids}"]
+
+  from_port = "${lookup(var.egress_with_ipv6_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.egress_with_ipv6_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.egress_with_ipv6_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 2))}"
 }
 
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,11 @@ variable "ingress_with_cidr_blocks" {
   default     = []
 }
 
+variable "ingress_with_ipv6_cidr_blocks" {
+  description = "List of ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
 variable "ingress_with_source_security_group_id" {
   description = "List of ingress rules to create where 'source_security_group_id' is used"
   default     = []
@@ -72,6 +77,11 @@ variable "egress_with_self" {
 
 variable "egress_with_cidr_blocks" {
   description = "List of egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "egress_with_ipv6_cidr_blocks" {
+  description = "List of egress rules to create where 'ipv6_cidr_blocks' is used"
   default     = []
 }
 


### PR DESCRIPTION
Fix #14 

There was a bug in this Terraform module when ipv4 and ipv6 CIDR blocks could be be specified in _some_ cases together, this PR fixes this bug by introducing these changes:
1. IPv6 values should be specified using `ingress_with_ipv6_cidr_blocks` and `egress_with_ipv6_cidr_blocks`.
2. IPv4 values should be specified using `ingress_with_cidr_blocks` and `egress_with_ipv6_cidr_blocks`

See `examples/complete/main.tf` for the detailed examples.