### PR TITLE
running terraform fmt for formatting fix

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -28,7 +28,9 @@ output "this_security_group_description" {
 //  value       = "${element(concat(aws_security_group.this.*.ingress, list("")), 0)}"
 //}
 
+
 //output "this_security_group_egress" {
 //  description = "The egress rules"
 //    value       = "${element(concat(aws_security_group.this.*.egress, list("")), 0)"
 //}
+


### PR DESCRIPTION
The downstream ALB module fails if formatting is wrong in any dependent module. I'll also start pinning my examples to known good module versions in light of this.