### PR TITLE
Revert "Specify minimum required version of AWS provider (>= 1.1.0)"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  version = ">= 1.1.0"
-}
-
 #################
 # Security group
 #################


### PR DESCRIPTION
Reverts terraform-aws-modules/terraform-aws-security-group#30

The reason for this revert is that it does not work for all current use-cases (see #31).