### PR TITLE
added rdp-udp, fixed typo in mssql-broker-tcp

### DIFF
--- a/modules/rdp/auto_values.tf
+++ b/modules/rdp/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = "list"
-  default     = ["rdp-tcp"]
+  default     = ["rdp-tcp", "rdp-udp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/rules.tf
+++ b/rules.tf
@@ -69,7 +69,7 @@ variable "rules" {
     mssql-tcp           = [1433, 1433, "tcp", "MSSQL Server"]
     mssql-udp           = [1434, 1434, "udp", "MSSQL Browser"]
     mssql-analytics-tcp = [2383, 2383, "tcp", "MSSQL Analytics"]
-    mssql-broker-tcp.   = [4022, 4022, "tcp", "MSSQL Broker"]
+    mssql-broker-tcp    = [4022, 4022, "tcp", "MSSQL Broker"]
 
     # NFS/EFS
     nfs-tcp = [2049, 2049, "tcp", "NFS/EFS"]
@@ -93,6 +93,7 @@ variable "rules" {
 
     # RDP
     rdp-tcp = [3389, 3389, "tcp", "Remote Desktop"]
+    rdp-udp = [3389, 3389, "udp", "Remote Desktop"]
 
     # Redis
     redis-tcp = [6379, 6379, "tcp", "Redis"]

--- a/rules.tf
+++ b/rules.tf
@@ -252,7 +252,7 @@ variable "auto_groups" {
     }
 
     rdp = {
-      ingress_rules     = ["rdp-tcp"]
+      ingress_rules     = ["rdp-tcp", "rdp-udp"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }


### PR DESCRIPTION
Two changes: Adding rdp-udp, which is supported since RDP 8.0 and offers better performance to clients connecting over unstable networks. This is also the recommended default by Microsoft.
Removing a "." from the end of mssql-broker-tcp, which I believe is a typo, but correct me if I'm wrong. 