### PR TITLE
 Fix ingress_with_source_security_group_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ module "bastion-security-group" {
 
 **Note:** it is not possible to use variable outputs from this module or other modules that contain calculated values when defining the security group resources. This is typically an issue when specifying either `ingress_with_source_security_group_id` or `egress_with_source_security_group_id` parameters and attempting to use the security group id of a resource which has not yet been created. However referencing variables that are already "hard-coded" in the .tf file (i.e. not calculated values dependent on the infrastructure being created) are fine. E.g. the VPC cidr block `"10.10.0.0/16"`. Also using data sources allows the use of external data/variables that are known at plan time and not regarded as calculated. More details [here](https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/16).
 
-##### 2. Security group with pre-defined rules (NOTE: Terraform should be version 0.11 or newer)
+##### 3. Security group with pre-defined rules (NOTE: Terraform should be version 0.11 or newer)
 
 ```hcl
 module "web_server_sg" {

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_security_group_rule" "ingress_rules" {
 ##########################
 # Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
 resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
-  count = "${var.create ? var.rules_count}"
+  count = "${var.create ? var.ingress_rules_count}"
 
   security_group_id = "${aws_security_group.this.id}"
   type              = "ingress"

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_security_group_rule" "ingress_rules" {
 ##########################
 # Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
 resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
-  count = "${var.create ? length(var.ingress_with_source_security_group_id) : 0}"
+  count = "${var.create ? var.rules_count}"
 
   security_group_id = "${aws_security_group.this.id}"
   type              = "ingress"


### PR DESCRIPTION
Fix ingress_with_source_security_group_id with a rules_count variables in order to be able to use SG's created with terraform