### PR TITLE
Fix openvpn rule name mismatch

### DIFF
--- a/modules/openvpn/auto_values.tf
+++ b/modules/openvpn/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = "list"
-  default     = ["openvpn-udp", "openvpn-tcp", "openvpn-443-tcp"]
+  default     = ["openvpn-udp", "openvpn-tcp", "openvpn-https-tcp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/rules.tf
+++ b/rules.tf
@@ -240,7 +240,7 @@ variable "auto_groups" {
     }
 
     openvpn = {
-      ingress_rules     = ["openvpn-udp", "openvpn-tcp", "openvpn-443-tcp"]
+      ingress_rules     = ["openvpn-udp", "openvpn-tcp", "openvpn-https-tcp"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }


### PR DESCRIPTION
- Simple fix, rule naming for OpenVPN was not consistent between the `defaults` and the `auto_groups`