### PR TITLE
removed duplicate forward slash in source

### DIFF
--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -4,7 +4,7 @@
 
 ```hcl
 module "ipsec_4500_security_group" {
-  source = "terraform-aws-modules/security-group/aws//modules/ipsec-4500"
+  source = "terraform-aws-modules/security-group/aws/modules/ipsec-4500"
 
   # omitted...
 }


### PR DESCRIPTION
From : source = "terraform-aws-modules/security-group/aws//modules/ipsec-4500"
To      :  source = "terraform-aws-modules/security-group/aws/modules/ipsec-4500"

in modules/ipsec-4500/README.md