### PR TITLE
Allow computed values in arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.1
+  rev: v1.7.3
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v1.2.3
+  rev: v1.3.0
   hooks:
     - id: check-merge-conflict

--- a/examples/computed/README.md
+++ b/examples/computed/README.md
@@ -1,0 +1,29 @@
+# Computed Security Group rules example
+
+Configuration in this directory creates set of Security Group and Security Group Rules resources in various combination.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this_security_group_description | The description of the security group |
+| this_security_group_id | The ID of the security group |
+| this_security_group_name | The name of the security group |
+| this_security_group_owner_id | The owner ID |
+| this_security_group_vpc_id | The VPC ID |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/computed/main.tf
+++ b/examples/computed/main.tf
@@ -1,0 +1,54 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+#############################################################
+# Data sources to get VPC and default security group details
+#############################################################
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_security_group" "default" {
+  name   = "default"
+  vpc_id = "${data.aws_vpc.default.id}"
+}
+
+###########################
+# Security groups examples
+###########################
+module "http_sg" {
+  source = "../../modules/https-443"
+
+  name        = "computed-http-sg"
+  description = "Security group with HTTP port open for everyone, and HTTPS open just for the default security group"
+  vpc_id      = "${data.aws_vpc.default.id}"
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+
+  ingress_with_source_security_group_id = [
+    {
+      rule                     = "https-443-tcp"
+      source_security_group_id = "${data.aws_security_group.default.id}"
+    },
+  ]
+}
+
+module "mysql_sg" {
+  source = "../../modules/mysql"
+
+  name        = "computed-mysql-sg"
+  description = "Security group with MySQL/Aurora port open for HTTP security group created above (computed)"
+  vpc_id      = "${data.aws_vpc.default.id}"
+
+  ingress_cidr_blocks = ["0.0.0.0/0"]
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "mysql-tcp"
+      source_security_group_id = "${module.http_sg.this_security_group_id}"
+    },
+  ]
+
+  number_of_computed_ingress_with_source_security_group_id = 1
+}

--- a/examples/computed/outputs.tf
+++ b/examples/computed/outputs.tf
@@ -1,0 +1,24 @@
+output "this_security_group_id" {
+  description = "The ID of the security group"
+  value       = "${module.mysql_sg.this_security_group_id}"
+}
+
+output "this_security_group_vpc_id" {
+  description = "The VPC ID"
+  value       = "${module.mysql_sg.this_security_group_vpc_id}"
+}
+
+output "this_security_group_owner_id" {
+  description = "The owner ID"
+  value       = "${module.mysql_sg.this_security_group_owner_id}"
+}
+
+output "this_security_group_name" {
+  description = "The name of the security group"
+  value       = "${module.mysql_sg.this_security_group_name}"
+}
+
+output "this_security_group_description" {
+  description = "The description of the security group"
+  value       = "${module.mysql_sg.this_security_group_description}"
+}

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,23 @@ resource "aws_security_group_rule" "ingress_rules" {
   protocol  = "${element(var.rules[var.ingress_rules[count.index]], 2)}"
 }
 
+# Computed - Security group rules with "cidr_blocks" and it uses list of rules names
+resource "aws_security_group_rule" "computed_ingress_rules" {
+  count = "${var.create ? var.number_of_computed_ingress_rules : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "ingress"
+
+  cidr_blocks      = ["${var.ingress_cidr_blocks}"]
+  ipv6_cidr_blocks = ["${var.ingress_ipv6_cidr_blocks}"]
+  prefix_list_ids  = ["${var.ingress_prefix_list_ids}"]
+  description      = "${element(var.rules[var.computed_ingress_rules[count.index]], 3)}"
+
+  from_port = "${element(var.rules[var.computed_ingress_rules[count.index]], 0)}"
+  to_port   = "${element(var.rules[var.computed_ingress_rules[count.index]], 1)}"
+  protocol  = "${element(var.rules[var.computed_ingress_rules[count.index]], 2)}"
+}
+
 ##########################
 # Ingress - Maps of rules
 ##########################
@@ -51,6 +68,23 @@ resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
   protocol  = "${lookup(var.ingress_with_source_security_group_id[count.index], "protocol", element(var.rules[lookup(var.ingress_with_source_security_group_id[count.index], "rule", "_")], 2))}"
 }
 
+# Computed - Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
+resource "aws_security_group_rule" "computed_ingress_with_source_security_group_id" {
+  count = "${var.create ? var.number_of_computed_ingress_with_source_security_group_id : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "ingress"
+
+  source_security_group_id = "${lookup(var.computed_ingress_with_source_security_group_id[count.index], "source_security_group_id")}"
+  ipv6_cidr_blocks         = ["${var.ingress_ipv6_cidr_blocks}"]
+  prefix_list_ids          = ["${var.ingress_prefix_list_ids}"]
+  description              = "${lookup(var.computed_ingress_with_source_security_group_id[count.index], "description", "Ingress Rule")}"
+
+  from_port = "${lookup(var.computed_ingress_with_source_security_group_id[count.index], "from_port", element(var.rules[lookup(var.computed_ingress_with_source_security_group_id[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_ingress_with_source_security_group_id[count.index], "to_port", element(var.rules[lookup(var.computed_ingress_with_source_security_group_id[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_ingress_with_source_security_group_id[count.index], "protocol", element(var.rules[lookup(var.computed_ingress_with_source_security_group_id[count.index], "rule", "_")], 2))}"
+}
+
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
   count = "${var.create ? length(var.ingress_with_cidr_blocks) : 0}"
@@ -65,6 +99,22 @@ resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
   from_port = "${lookup(var.ingress_with_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")], 0))}"
   to_port   = "${lookup(var.ingress_with_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")], 1))}"
   protocol  = "${lookup(var.ingress_with_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.ingress_with_cidr_blocks[count.index], "rule", "_")], 2))}"
+}
+
+# Computed - Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
+resource "aws_security_group_rule" "computed_ingress_with_cidr_blocks" {
+  count = "${var.create ? var.number_of_computed_ingress_with_cidr_blocks : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "ingress"
+
+  cidr_blocks     = ["${split(",", lookup(var.computed_ingress_with_cidr_blocks[count.index], "cidr_blocks", join(",", var.ingress_cidr_blocks)))}"]
+  prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
+  description     = "${lookup(var.computed_ingress_with_cidr_blocks[count.index], "description", "Ingress Rule")}"
+
+  from_port = "${lookup(var.computed_ingress_with_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.computed_ingress_with_cidr_blocks[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_ingress_with_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.computed_ingress_with_cidr_blocks[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_ingress_with_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.computed_ingress_with_cidr_blocks[count.index], "rule", "_")], 2))}"
 }
 
 # Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
@@ -83,6 +133,22 @@ resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
   protocol  = "${lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 2))}"
 }
 
+# Computed - Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
+resource "aws_security_group_rule" "computed_ingress_with_ipv6_cidr_blocks" {
+  count = "${var.create ? var.number_of_computed_ingress_with_ipv6_cidr_blocks : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "ingress"
+
+  ipv6_cidr_blocks = ["${split(",", lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "ipv6_cidr_blocks", join(",", var.ingress_ipv6_cidr_blocks)))}"]
+  prefix_list_ids  = ["${var.ingress_prefix_list_ids}"]
+  description      = "${lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "description", "Ingress Rule")}"
+
+  from_port = "${lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.computed_ingress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 2))}"
+}
+
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
 resource "aws_security_group_rule" "ingress_with_self" {
   count = "${var.create ? length(var.ingress_with_self) : 0}"
@@ -98,6 +164,23 @@ resource "aws_security_group_rule" "ingress_with_self" {
   from_port = "${lookup(var.ingress_with_self[count.index], "from_port", element(var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")], 0))}"
   to_port   = "${lookup(var.ingress_with_self[count.index], "to_port", element(var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")], 1))}"
   protocol  = "${lookup(var.ingress_with_self[count.index], "protocol", element(var.rules[lookup(var.ingress_with_self[count.index], "rule", "_")], 2))}"
+}
+
+# Computed - Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
+resource "aws_security_group_rule" "computed_ingress_with_self" {
+  count = "${var.create ? var.number_of_computed_ingress_with_self : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "ingress"
+
+  self             = "${lookup(var.computed_ingress_with_self[count.index], "self", true)}"
+  ipv6_cidr_blocks = ["${var.ingress_ipv6_cidr_blocks}"]
+  prefix_list_ids  = ["${var.ingress_prefix_list_ids}"]
+  description      = "${lookup(var.computed_ingress_with_self[count.index], "description", "Ingress Rule")}"
+
+  from_port = "${lookup(var.computed_ingress_with_self[count.index], "from_port", element(var.rules[lookup(var.computed_ingress_with_self[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_ingress_with_self[count.index], "to_port", element(var.rules[lookup(var.computed_ingress_with_self[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_ingress_with_self[count.index], "protocol", element(var.rules[lookup(var.computed_ingress_with_self[count.index], "rule", "_")], 2))}"
 }
 
 #################
@@ -124,6 +207,23 @@ resource "aws_security_group_rule" "egress_rules" {
   protocol  = "${element(var.rules[var.egress_rules[count.index]], 2)}"
 }
 
+# Computed - Security group rules with "cidr_blocks" and it uses list of rules names
+resource "aws_security_group_rule" "computed_egress_rules" {
+  count = "${var.create ? var.number_of_computed_egress_rules : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "egress"
+
+  cidr_blocks      = ["${var.egress_cidr_blocks}"]
+  ipv6_cidr_blocks = ["${var.egress_ipv6_cidr_blocks}"]
+  prefix_list_ids  = ["${var.egress_prefix_list_ids}"]
+  description      = "${element(var.rules[var.computed_egress_rules[count.index]], 3)}"
+
+  from_port = "${element(var.rules[var.computed_egress_rules[count.index]], 0)}"
+  to_port   = "${element(var.rules[var.computed_egress_rules[count.index]], 1)}"
+  protocol  = "${element(var.rules[var.computed_egress_rules[count.index]], 2)}"
+}
+
 #########################
 # Egress - Maps of rules
 #########################
@@ -144,6 +244,23 @@ resource "aws_security_group_rule" "egress_with_source_security_group_id" {
   protocol  = "${lookup(var.egress_with_source_security_group_id[count.index], "protocol", element(var.rules[lookup(var.egress_with_source_security_group_id[count.index], "rule", "_")], 2))}"
 }
 
+# Computed - Security group rules with "source_security_group_id", but without "cidr_blocks" and "self"
+resource "aws_security_group_rule" "computed_egress_with_source_security_group_id" {
+  count = "${var.create ? var.number_of_computed_egress_with_source_security_group_id : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "egress"
+
+  source_security_group_id = "${lookup(var.computed_egress_with_source_security_group_id[count.index], "source_security_group_id")}"
+  ipv6_cidr_blocks         = ["${var.egress_ipv6_cidr_blocks}"]
+  prefix_list_ids          = ["${var.egress_prefix_list_ids}"]
+  description              = "${lookup(var.computed_egress_with_source_security_group_id[count.index], "description", "Egress Rule")}"
+
+  from_port = "${lookup(var.computed_egress_with_source_security_group_id[count.index], "from_port", element(var.rules[lookup(var.computed_egress_with_source_security_group_id[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_egress_with_source_security_group_id[count.index], "to_port", element(var.rules[lookup(var.computed_egress_with_source_security_group_id[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_egress_with_source_security_group_id[count.index], "protocol", element(var.rules[lookup(var.computed_egress_with_source_security_group_id[count.index], "rule", "_")], 2))}"
+}
+
 # Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
 resource "aws_security_group_rule" "egress_with_cidr_blocks" {
   count = "${var.create ? length(var.egress_with_cidr_blocks) : 0}"
@@ -158,6 +275,22 @@ resource "aws_security_group_rule" "egress_with_cidr_blocks" {
   from_port = "${lookup(var.egress_with_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")], 0))}"
   to_port   = "${lookup(var.egress_with_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")], 1))}"
   protocol  = "${lookup(var.egress_with_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.egress_with_cidr_blocks[count.index], "rule", "_")], 2))}"
+}
+
+# Computed - Security group rules with "cidr_blocks", but without "ipv6_cidr_blocks", "source_security_group_id" and "self"
+resource "aws_security_group_rule" "computed_egress_with_cidr_blocks" {
+  count = "${var.create ? var.number_of_computed_egress_with_cidr_blocks : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "egress"
+
+  cidr_blocks     = ["${split(",", lookup(var.computed_egress_with_cidr_blocks[count.index], "cidr_blocks", join(",", var.egress_cidr_blocks)))}"]
+  prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+  description     = "${lookup(var.computed_egress_with_cidr_blocks[count.index], "description", "Egress Rule")}"
+
+  from_port = "${lookup(var.computed_egress_with_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.computed_egress_with_cidr_blocks[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_egress_with_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.computed_egress_with_cidr_blocks[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_egress_with_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.computed_egress_with_cidr_blocks[count.index], "rule", "_")], 2))}"
 }
 
 # Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
@@ -176,6 +309,22 @@ resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
   protocol  = "${lookup(var.egress_with_ipv6_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 2))}"
 }
 
+# Computed - Security group rules with "ipv6_cidr_blocks", but without "cidr_blocks", "source_security_group_id" and "self"
+resource "aws_security_group_rule" "computed_egress_with_ipv6_cidr_blocks" {
+  count = "${var.create ? var.number_of_computed_egress_with_ipv6_cidr_blocks : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "egress"
+
+  ipv6_cidr_blocks = ["${split(",", lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "ipv6_cidr_blocks", join(",", var.egress_ipv6_cidr_blocks)))}"]
+  prefix_list_ids  = ["${var.egress_prefix_list_ids}"]
+  description      = "${lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "description", "Egress Rule")}"
+
+  from_port = "${lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "from_port", element(var.rules[lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "to_port", element(var.rules[lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "protocol", element(var.rules[lookup(var.computed_egress_with_ipv6_cidr_blocks[count.index], "rule", "_")], 2))}"
+}
+
 # Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
 resource "aws_security_group_rule" "egress_with_self" {
   count = "${var.create ? length(var.egress_with_self) : 0}"
@@ -191,6 +340,23 @@ resource "aws_security_group_rule" "egress_with_self" {
   from_port = "${lookup(var.egress_with_self[count.index], "from_port", element(var.rules[lookup(var.egress_with_self[count.index], "rule", "_")], 0))}"
   to_port   = "${lookup(var.egress_with_self[count.index], "to_port", element(var.rules[lookup(var.egress_with_self[count.index], "rule", "_")], 1))}"
   protocol  = "${lookup(var.egress_with_self[count.index], "protocol", element(var.rules[lookup(var.egress_with_self[count.index], "rule", "_")], 2))}"
+}
+
+# Computed - Security group rules with "self", but without "cidr_blocks" and "source_security_group_id"
+resource "aws_security_group_rule" "computed_egress_with_self" {
+  count = "${var.create ? var.number_of_computed_egress_with_self : 0}"
+
+  security_group_id = "${aws_security_group.this.id}"
+  type              = "egress"
+
+  self             = "${lookup(var.computed_egress_with_self[count.index], "self", true)}"
+  ipv6_cidr_blocks = ["${var.egress_ipv6_cidr_blocks}"]
+  prefix_list_ids  = ["${var.egress_prefix_list_ids}"]
+  description      = "${lookup(var.computed_egress_with_self[count.index], "description", "Egress Rule")}"
+
+  from_port = "${lookup(var.computed_egress_with_self[count.index], "from_port", element(var.rules[lookup(var.computed_egress_with_self[count.index], "rule", "_")], 0))}"
+  to_port   = "${lookup(var.computed_egress_with_self[count.index], "to_port", element(var.rules[lookup(var.computed_egress_with_self[count.index], "rule", "_")], 1))}"
+  protocol  = "${lookup(var.computed_egress_with_self[count.index], "protocol", element(var.rules[lookup(var.computed_egress_with_self[count.index], "rule", "_")], 2))}"
 }
 
 ################

--- a/modules/_templates/main.tf
+++ b/modules/_templates/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/_templates/variables.tf
+++ b/modules/_templates/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/carbon-relay-ng/README.md
+++ b/modules/carbon-relay-ng/README.md
@@ -18,10 +18,34 @@ All automatic values **carbon-relay-ng module** is using are available [here](ht
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **carbon-relay-ng module** is using are available [here](ht
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/carbon-relay-ng/auto_values.tf
+++ b/modules/carbon-relay-ng/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/carbon-relay-ng/main.tf
+++ b/modules/carbon-relay-ng/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/carbon-relay-ng/variables.tf
+++ b/modules/carbon-relay-ng/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -18,10 +18,34 @@ All automatic values **cassandra module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **cassandra module** is using are available [here](https://
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/cassandra/auto_values.tf
+++ b/modules/cassandra/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/cassandra/main.tf
+++ b/modules/cassandra/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/cassandra/variables.tf
+++ b/modules/cassandra/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -18,10 +18,34 @@ All automatic values **consul module** is using are available [here](https://git
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **consul module** is using are available [here](https://git
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/consul/auto_values.tf
+++ b/modules/consul/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/consul/main.tf
+++ b/modules/consul/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/consul/variables.tf
+++ b/modules/consul/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/docker-swarm/README.md
+++ b/modules/docker-swarm/README.md
@@ -18,10 +18,34 @@ All automatic values **docker-swarm module** is using are available [here](https
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **docker-swarm module** is using are available [here](https
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/docker-swarm/auto_values.tf
+++ b/modules/docker-swarm/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/docker-swarm/main.tf
+++ b/modules/docker-swarm/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/docker-swarm/variables.tf
+++ b/modules/docker-swarm/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -18,10 +18,34 @@ All automatic values **elasticsearch module** is using are available [here](http
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **elasticsearch module** is using are available [here](http
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/elasticsearch/auto_values.tf
+++ b/modules/elasticsearch/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/http-80/README.md
+++ b/modules/http-80/README.md
@@ -18,10 +18,34 @@ All automatic values **http-80 module** is using are available [here](https://gi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **http-80 module** is using are available [here](https://gi
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/http-80/auto_values.tf
+++ b/modules/http-80/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/http-80/main.tf
+++ b/modules/http-80/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/http-80/variables.tf
+++ b/modules/http-80/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/https-443/README.md
+++ b/modules/https-443/README.md
@@ -18,10 +18,34 @@ All automatic values **https-443 module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **https-443 module** is using are available [here](https://
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/https-443/auto_values.tf
+++ b/modules/https-443/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/https-443/main.tf
+++ b/modules/https-443/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/https-443/variables.tf
+++ b/modules/https-443/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -18,10 +18,34 @@ All automatic values **ipsec-4500 module** is using are available [here](https:/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **ipsec-4500 module** is using are available [here](https:/
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/ipsec-4500/auto_values.tf
+++ b/modules/ipsec-4500/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/ipsec-4500/main.tf
+++ b/modules/ipsec-4500/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/ipsec-4500/variables.tf
+++ b/modules/ipsec-4500/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/ipsec-500/README.md
+++ b/modules/ipsec-500/README.md
@@ -18,10 +18,34 @@ All automatic values **ipsec-500 module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **ipsec-500 module** is using are available [here](https://
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/ipsec-500/auto_values.tf
+++ b/modules/ipsec-500/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/ipsec-500/main.tf
+++ b/modules/ipsec-500/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/ipsec-500/variables.tf
+++ b/modules/ipsec-500/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -18,10 +18,34 @@ All automatic values **kafka module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **kafka module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/kafka/auto_values.tf
+++ b/modules/kafka/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/kafka/main.tf
+++ b/modules/kafka/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/kafka/variables.tf
+++ b/modules/kafka/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/ldaps/README.md
+++ b/modules/ldaps/README.md
@@ -18,10 +18,34 @@ All automatic values **ldaps module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **ldaps module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/ldaps/auto_values.tf
+++ b/modules/ldaps/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/ldaps/main.tf
+++ b/modules/ldaps/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/ldaps/variables.tf
+++ b/modules/ldaps/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/memcached/README.md
+++ b/modules/memcached/README.md
@@ -18,10 +18,34 @@ All automatic values **memcached module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **memcached module** is using are available [here](https://
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/memcached/auto_values.tf
+++ b/modules/memcached/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/memcached/main.tf
+++ b/modules/memcached/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/memcached/variables.tf
+++ b/modules/memcached/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -18,10 +18,34 @@ All automatic values **mssql module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **mssql module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/mssql/auto_values.tf
+++ b/modules/mssql/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -18,10 +18,34 @@ All automatic values **mysql module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **mysql module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/mysql/auto_values.tf
+++ b/modules/mysql/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/nfs/README.md
+++ b/modules/nfs/README.md
@@ -18,10 +18,34 @@ All automatic values **nfs module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **nfs module** is using are available [here](https://github
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/nfs/auto_values.tf
+++ b/modules/nfs/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/nfs/main.tf
+++ b/modules/nfs/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/nfs/variables.tf
+++ b/modules/nfs/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -18,10 +18,34 @@ All automatic values **nomad module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **nomad module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/nomad/auto_values.tf
+++ b/modules/nomad/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/nomad/main.tf
+++ b/modules/nomad/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -18,10 +18,34 @@ All automatic values **openvpn module** is using are available [here](https://gi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **openvpn module** is using are available [here](https://gi
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/openvpn/auto_values.tf
+++ b/modules/openvpn/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/openvpn/main.tf
+++ b/modules/openvpn/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/openvpn/variables.tf
+++ b/modules/openvpn/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/oracle-db/README.md
+++ b/modules/oracle-db/README.md
@@ -18,10 +18,34 @@ All automatic values **oracle-db module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **oracle-db module** is using are available [here](https://
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/oracle-db/auto_values.tf
+++ b/modules/oracle-db/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/oracle-db/main.tf
+++ b/modules/oracle-db/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/oracle-db/variables.tf
+++ b/modules/oracle-db/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -18,10 +18,34 @@ All automatic values **postgresql module** is using are available [here](https:/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **postgresql module** is using are available [here](https:/
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/postgresql/auto_values.tf
+++ b/modules/postgresql/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/rdp/README.md
+++ b/modules/rdp/README.md
@@ -18,10 +18,34 @@ All automatic values **rdp module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **rdp module** is using are available [here](https://github
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/rdp/auto_values.tf
+++ b/modules/rdp/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/rdp/main.tf
+++ b/modules/rdp/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/rdp/variables.tf
+++ b/modules/rdp/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -18,10 +18,34 @@ All automatic values **redis module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **redis module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/redis/auto_values.tf
+++ b/modules/redis/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/redshift/README.md
+++ b/modules/redshift/README.md
@@ -18,10 +18,34 @@ All automatic values **redshift module** is using are available [here](https://g
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **redshift module** is using are available [here](https://g
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/redshift/auto_values.tf
+++ b/modules/redshift/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/redshift/main.tf
+++ b/modules/redshift/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/redshift/variables.tf
+++ b/modules/redshift/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/splunk/README.md
+++ b/modules/splunk/README.md
@@ -18,10 +18,34 @@ All automatic values **splunk module** is using are available [here](https://git
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **splunk module** is using are available [here](https://git
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/splunk/auto_values.tf
+++ b/modules/splunk/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/splunk/main.tf
+++ b/modules/splunk/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/splunk/variables.tf
+++ b/modules/splunk/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -18,10 +18,34 @@ All automatic values **ssh module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **ssh module** is using are available [here](https://github
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/ssh/auto_values.tf
+++ b/modules/ssh/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/ssh/main.tf
+++ b/modules/ssh/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/ssh/variables.tf
+++ b/modules/ssh/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/storm/README.md
+++ b/modules/storm/README.md
@@ -18,10 +18,34 @@ All automatic values **storm module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **storm module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/storm/auto_values.tf
+++ b/modules/storm/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/storm/main.tf
+++ b/modules/storm/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/storm/variables.tf
+++ b/modules/storm/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -18,10 +18,34 @@ All automatic values **web module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **web module** is using are available [here](https://github
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/web/auto_values.tf
+++ b/modules/web/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/winrm/README.md
+++ b/modules/winrm/README.md
@@ -18,10 +18,34 @@ All automatic values **winrm module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **winrm module** is using are available [here](https://gith
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/winrm/auto_values.tf
+++ b/modules/winrm/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/winrm/main.tf
+++ b/modules/winrm/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/winrm/variables.tf
+++ b/modules/winrm/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/zipkin/README.md
+++ b/modules/zipkin/README.md
@@ -18,10 +18,34 @@ All automatic values **zipkin module** is using are available [here](https://git
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **zipkin module** is using are available [here](https://git
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/zipkin/auto_values.tf
+++ b/modules/zipkin/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/zipkin/main.tf
+++ b/modules/zipkin/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/zipkin/variables.tf
+++ b/modules/zipkin/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -18,10 +18,34 @@ All automatic values **zookeeper module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
+| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
+| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
+| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
 | auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
 | auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
 | auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
 | auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
+| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `<list>` | no |
+| computed_egress_rules | List of computed egress rules to create by name | string | `<list>` | no |
+| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
+| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `<list>` | no |
+| computed_ingress_rules | List of computed ingress rules to create by name | string | `<list>` | no |
+| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `<list>` | no |
+| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
+| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -41,6 +65,22 @@ All automatic values **zookeeper module** is using are available [here](https://
 | ingress_with_self | List of ingress rules to create where 'self' is defined | string | `<list>` | no |
 | ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | name | Name of security group | string | - | yes |
+| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |
 

--- a/modules/zookeeper/auto_values.tf
+++ b/modules/zookeeper/auto_values.tf
@@ -29,3 +29,49 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = []
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}

--- a/modules/zookeeper/main.tf
+++ b/modules/zookeeper/main.tf
@@ -32,6 +32,34 @@ module "sg" {
   # Default prefix list ids
   ingress_prefix_list_ids = ["${var.ingress_prefix_list_ids}"]
 
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = ["${sort(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules)))}"]
+
+  # Open for self
+  computed_ingress_with_self = ["${concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = ["${var.computed_ingress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = ["${var.computed_ingress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = ["${var.computed_ingress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules = "${var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules}"
+
+  number_of_computed_ingress_with_self                     = "${var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self}"
+  number_of_computed_ingress_with_cidr_blocks              = "${var.number_of_computed_ingress_with_cidr_blocks}"
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = "${var.number_of_computed_ingress_with_ipv6_cidr_blocks}"
+  number_of_computed_ingress_with_source_security_group_id = "${var.number_of_computed_ingress_with_source_security_group_id}"
+
   #########
   # Egress
   #########
@@ -56,4 +84,32 @@ module "sg" {
 
   # Default prefix list ids
   egress_prefix_list_ids = ["${var.egress_prefix_list_ids}"]
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = ["${sort(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules)))}"]
+
+  # Open for self
+  computed_egress_with_self = ["${concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)}"]
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = ["${var.computed_egress_with_cidr_blocks}"]
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = ["${var.computed_egress_with_ipv6_cidr_blocks}"]
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = ["${var.computed_egress_with_source_security_group_id}"]
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules = "${var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules}"
+
+  number_of_computed_egress_with_self                     = "${var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self}"
+  number_of_computed_egress_with_cidr_blocks              = "${var.number_of_computed_egress_with_cidr_blocks}"
+  number_of_computed_egress_with_ipv6_cidr_blocks         = "${var.number_of_computed_egress_with_ipv6_cidr_blocks}"
+  number_of_computed_egress_with_source_security_group_id = "${var.number_of_computed_egress_with_source_security_group_id}"
 }

--- a/modules/zookeeper/variables.tf
+++ b/modules/zookeeper/variables.tf
@@ -67,6 +67,92 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +194,90 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  default     = 0
 }

--- a/update_groups.sh
+++ b/update_groups.sh
@@ -49,6 +49,14 @@ set_list_if_null() {
   fi
 }
 
+set_zero_if_null() {
+  if [[ "null" == "$1" ]]; then
+    echo 0
+  else
+    echo "$1"
+  fi
+}
+
 main() {
   check_dependencies
 
@@ -80,11 +88,35 @@ main() {
     egress_rules=$(get_auto_value "$auto_groups_data" "$group" "egress_rules")
     egress_with_self=$(get_auto_value "$auto_groups_data" "$group" "egress_with_self")
 
+    # Computed values
+    computed_ingress_rules=$(get_auto_value "$auto_groups_data" "$group" "computed_ingress_rules")
+    computed_ingress_with_self=$(get_auto_value "$auto_groups_data" "$group" "computed_ingress_with_self")
+    computed_egress_rules=$(get_auto_value "$auto_groups_data" "$group" "computed_egress_rules")
+    computed_egress_with_self=$(get_auto_value "$auto_groups_data" "$group" "computed_egress_with_self")
+
+    # Number of computed values
+    number_of_computed_ingress_rules=$(get_auto_value "$auto_groups_data" "$group" "number_of_computed_ingress_rules")
+    number_of_computed_ingress_with_self=$(get_auto_value "$auto_groups_data" "$group" "number_of_computed_ingress_with_self")
+    number_of_computed_egress_rules=$(get_auto_value "$auto_groups_data" "$group" "number_of_computed_egress_rules")
+    number_of_computed_egress_with_self=$(get_auto_value "$auto_groups_data" "$group" "number_of_computed_egress_with_self")
+
     # Set to empty lists, if no value was specified
     ingress_rules=$(set_list_if_null "$ingress_rules")
     ingress_with_self=$(set_list_if_null "$ingress_with_self")
     egress_rules=$(set_list_if_null "$egress_rules")
     egress_with_self=$(set_list_if_null "$egress_with_self")
+
+    # Set to empty lists, if no computed value was specified
+    computed_ingress_rules=$(set_list_if_null "$computed_ingress_rules")
+    computed_ingress_with_self=$(set_list_if_null "$computed_ingress_with_self")
+    computed_egress_rules=$(set_list_if_null "$computed_egress_rules")
+    computed_egress_with_self=$(set_list_if_null "$computed_egress_with_self")
+
+    # Set to zero, if no value was specified
+    number_of_computed_ingress_rules=$(set_zero_if_null "$number_of_computed_ingress_rules")
+    number_of_computed_ingress_with_self=$(set_zero_if_null "$number_of_computed_ingress_with_self")
+    number_of_computed_egress_rules=$(set_zero_if_null "$number_of_computed_egress_rules")
+    number_of_computed_egress_with_self=$(set_zero_if_null "$number_of_computed_egress_with_self")
 
     # ingress_with_self and egress_with_self are stored as simple lists (like this - ["all-all","all-tcp"]),
     # so we make map (like this - [{"rule"="all-all"},{"rule"="all-tcp"}])
@@ -120,6 +152,53 @@ variable "auto_egress_with_self" {
   type        = "list"
   default     = $egress_with_self
 }
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = "list"
+  default     = $computed_ingress_rules
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = "list"
+  default     = $computed_ingress_with_self
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = "list"
+  default     = $computed_egress_rules
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = "list"
+  default     = $computed_egress_with_self
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = $number_of_computed_ingress_rules
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = $number_of_computed_ingress_with_self
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = $number_of_computed_egress_rules
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = $number_of_computed_egress_with_self
+}
+
 EOF
 
     cat <<EOF > "modules/$group/README.md"

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,62 @@ variable "ingress_prefix_list_ids" {
   default     = []
 }
 
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  default     = 0
+}
+
 #########
 # Egress
 #########
@@ -108,4 +164,60 @@ variable "egress_ipv6_cidr_blocks" {
 variable "egress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
   default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  default     = 0
 }


### PR DESCRIPTION
It allows to specify computed values inside `source_security_group_id` as well as in all other arguments. See README for details.

Fixes #48 and few others.

This PR is backward-compatible.