### PR TITLE
Fix source of predefined rule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are two ways to create security groups using this module:
 
 ```hcl
 module "web_server_sg" {
-  source = "terraform-aws-modules/security-group/aws//modules/http"
+  source = "terraform-aws-modules/security-group/aws//modules/http-80"
 
   name        = "web-server"
   description = "Security group for web-server with HTTP ports open within VPC"


### PR DESCRIPTION
The current predefined rule example generate the following error:

```shell
  Found version 2.1.0 of terraform-aws-modules/security-group/aws on registry.terraform.io
  Getting source "terraform-aws-modules/security-group/aws//modules/http"
Error loading modules: subdir "*/modules/http" not found
```