### PR TITLE
Make creation of the security group optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Rules and groups are defined in [rules.tf](https://github.com/terraform-aws-modu
 | computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | string | `<list>` | no |
 | computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | string | `<list>` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
+| create_group | Whether to create security group | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
 | egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | string | `<list>` | no |
 | egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | string | `<list>` | no |
@@ -197,6 +198,7 @@ Rules and groups are defined in [rules.tf](https://github.com/terraform-aws-modu
 | number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
 | number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
 | rules | Map of known security group rules (define as 'name' = ['from port', 'to port', 'protocol', 'description']) | map | `<map>` | no |
+| security_group_id | ID of existing security group whose rules we will manage | string | `` | no |
 | tags | A mapping of tags to assign to security group | string | `<map>` | no |
 | use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
 | vpc_id | ID of the VPC where to create security group | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -2,14 +2,14 @@
 # Get ID of created Security Group
 ##################################
 locals {
-  this_sg_id = "${element(concat(coalescelist(aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id), list("")), 0)}"
+  this_sg_id = "${element(concat(coalescelist(list(var.security_group_id), aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id), list("")), 0)}"
 }
 
 ##########################
 # Security group with name
 ##########################
 resource "aws_security_group" "this" {
-  count = "${var.create && ! var.use_name_prefix ? 1 : 0}"
+  count = "${var.create && var.create_group && ! var.use_name_prefix ? 1 : 0}"
 
   name        = "${var.name}"
   description = "${var.description}"
@@ -22,7 +22,7 @@ resource "aws_security_group" "this" {
 # Security group with name_prefix
 #################################
 resource "aws_security_group" "this_name_prefix" {
-  count = "${var.create && var.use_name_prefix ? 1 : 0}"
+  count = "${var.create && var.create_group && var.use_name_prefix ? 1 : 0}"
 
   name_prefix = "${var.name}-"
   description = "${var.description}"

--- a/variables.tf
+++ b/variables.tf
@@ -6,6 +6,16 @@ variable "create" {
   default     = true
 }
 
+variable "create_group" {
+  description = "Whether to create security group"
+  default     = true
+}
+
+variable "security_group_id" {
+  description = "ID of existing security group whose rules we will manage"
+  default     = ""
+}
+
 variable "vpc_id" {
   description = "ID of the VPC where to create security group"
 }


### PR DESCRIPTION
This is an possible way of using this module to manage the rules of an existing Security Group.

One possible use case for this is this situation:

* group 1 - allow access from group 2
* group 2 - allow access from group 1

This causes circular dependencies as the rules of group 1 require the ID of group 2 and vice versa.

By creating the empty groups first and then adding the rules, circular dependencies are avoided.

I've not yet updated the documentation or examples, but I thought I'd push early to get feedback.

Usage would be something like:

```hcl
locals {
  sg_name        = "foo"
  sg_descrpition = "description"
}

resource "aws_security_group" "foo" {
  name        = "${local.sg_name}"
  description = "${local.sg_description}"
}

module "foo_rules" {
  source  = "terraform-aws-modules/security-group/aws"
  version = "2.6.0"

  create_group      = false
  security_group_id = "${aws_security_group.foo.id}"
  name              = "${local.sg_name}"
  description       = "${local.sg_description}"

  # rest of params
}
```

I'd ideally like to not pass in name and description if we're not creating the group but I'm not sure how best to do that.