### PR TITLE
Extended Splunk module to includ HEC

### DIFF
--- a/modules/splunk/auto_values.tf
+++ b/modules/splunk/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = "list"
-  default     = ["splunk-indexer-tcp", "splunk-clients-tcp", "splunk-splunkd-tcp"]
+  default     = ["splunk-indexer-tcp", "splunk-clients-tcp", "splunk-splunkd-tcp", "splunk-hec-tcp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/rules.tf
+++ b/rules.tf
@@ -108,6 +108,7 @@ variable "rules" {
     splunk-indexer-tcp = [9997, 9997, "tcp", "Splunk indexer"]
     splunk-clients-tcp = [8080, 8080, "tcp", "Splunk clients"]
     splunk-splunkd-tcp = [8089, 8089, "tcp", "Splunkd"]
+    splunk-hec-tcp = [8088, 8088, "tcp", "Splunk HEC"]
 
     # Squid
     squid-proxy-tcp = [3128, 3128, "tcp", "Squid default proxy"]
@@ -291,7 +292,7 @@ variable "auto_groups" {
     }
 
     splunk = {
-      ingress_rules     = ["splunk-indexer-tcp", "splunk-clients-tcp", "splunk-splunkd-tcp"]
+      ingress_rules     = ["splunk-indexer-tcp", "splunk-clients-tcp", "splunk-splunkd-tcp", "splunk-hec-tcp"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }


### PR DESCRIPTION
Extends the Splunk module to include the HTTP Event Collector.

* http://docs.splunk.com/Documentation/Splunk/7.1.3/Data/AboutHEC
* http://dev.splunk.com/view/event-collector/SP-CAAAE7F