### PR TITLE
Allow use_name_prefix override in submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.7.3
+  rev: v1.8.1
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v1.3.0
+  rev: v2.1.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -155,60 +155,60 @@ Rules and groups are defined in [rules.tf](https://github.com/terraform-aws-modu
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_groups | Map of groups of security group rules to use to generate modules (see update_groups.sh) | map | `<map>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_groups | Map of groups of security group rules to use to generate modules (see update_groups.sh) | map | `{ "carbon-relay-ng": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "carbon-line-in-tcp", "carbon-line-in-udp", "carbon-pickle-tcp", "carbon-pickle-udp", "carbon-gui-udp" ], "ingress_with_self": [ "all-all" ] } ], "cassandra": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "cassandra-clients-tcp", "cassandra-thrift-clients-tcp", "cassandra-jmx-tcp" ], "ingress_with_self": [ "all-all" ] } ], "consul": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "consul-tcp", "consul-cli-rpc-tcp", "consul-webui-tcp", "consul-dns-tcp", "consul-dns-udp", "consul-serf-lan-tcp", "consul-serf-lan-udp", "consul-serf-wan-tcp", "consul-serf-wan-udp" ], "ingress_with_self": [ "all-all" ] } ], "docker-swarm": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "docker-swarm-mngmt-tcp", "docker-swarm-node-tcp", "docker-swarm-node-udp", "docker-swarm-overlay-udp" ], "ingress_with_self": [ "all-all" ] } ], "elasticsearch": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "elasticsearch-rest-tcp", "elasticsearch-java-tcp" ], "ingress_with_self": [ "all-all" ] } ], "http-80": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "http-80-tcp" ], "ingress_with_self": [ "all-all" ] } ], "https-443": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "https-443-tcp" ], "ingress_with_self": [ "all-all" ] } ], "ipsec-4500": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "ipsec-4500-udp" ], "ingress_with_self": [ "all-all" ] } ], "ipsec-500": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "ipsec-500-udp" ], "ingress_with_self": [ "all-all" ] } ], "kafka": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "kafka-broker-tcp" ], "ingress_with_self": [ "all-all" ] } ], "ldaps": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "ldaps-tcp" ], "ingress_with_self": [ "all-all" ] } ], "memcached": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "memcached-tcp" ], "ingress_with_self": [ "all-all" ] } ], "mssql": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "mssql-tcp", "mssql-udp", "mssql-analytics-tcp", "mssql-broker-tcp" ], "ingress_with_self": [ "all-all" ] } ], "mysql": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "mysql-tcp" ], "ingress_with_self": [ "all-all" ] } ], "nfs": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "nfs-tcp" ], "ingress_with_self": [ "all-all" ] } ], "nomad": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "nomad-http-tcp", "nomad-rpc-tcp", "nomad-serf-tcp", "nomad-serf-udp" ], "ingress_with_self": [ "all-all" ] } ], "ntp": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "ntp-udp" ], "ingress_with_self": [ "all-all" ] } ], "openvpn": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "openvpn-udp", "openvpn-tcp", "openvpn-https-tcp" ], "ingress_with_self": [ "all-all" ] } ], "oracle-db": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "oracle-db-tcp" ], "ingress_with_self": [ "all-all" ] } ], "postgresql": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "postgresql-tcp" ], "ingress_with_self": [ "all-all" ] } ], "rdp": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "rdp-tcp", "rdp-udp" ], "ingress_with_self": [ "all-all" ] } ], "redis": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "redis-tcp" ], "ingress_with_self": [ "all-all" ] } ], "redshift": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "redshift-tcp" ], "ingress_with_self": [ "all-all" ] } ], "splunk": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "splunk-indexer-tcp", "splunk-clients-tcp", "splunk-splunkd-tcp", "splunk-hec-tcp" ], "ingress_with_self": [ "all-all" ] } ], "squid": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "squid-proxy-tcp" ], "ingress_with_self": [ "all-all" ] } ], "ssh": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "ssh-tcp" ], "ingress_with_self": [ "all-all" ] } ], "storm": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "storm-nimbus-tcp", "storm-ui-tcp", "storm-supervisor-tcp" ], "ingress_with_self": [ "all-all" ] } ], "web": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "http-80-tcp", "http-8080-tcp", "https-443-tcp", "web-jmx-tcp" ], "ingress_with_self": [ "all-all" ] } ], "winrm": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "winrm-http-tcp", "winrm-https-tcp" ], "ingress_with_self": [ "all-all" ] } ], "zipkin": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "zipkin-admin-tcp", "zipkin-admin-query-tcp", "zipkin-admin-web-tcp", "zipkin-query-tcp", "zipkin-web-tcp" ], "ingress_with_self": [ "all-all" ] } ], "zookeeper": [ { "egress_rules": [ "all-all" ], "ingress_rules": [ "zookeeper-2181-tcp", "zookeeper-2888-tcp", "zookeeper-3888-tcp", "zookeeper-jmx-tcp" ], "ingress_with_self": [ "all-all" ] } ] }` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| rules | Map of known security group rules (define as 'name' = ['from port', 'to port', 'protocol', 'description']) | map | `<map>` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| use_name_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| rules | Map of known security group rules (define as 'name' = ['from port', 'to port', 'protocol', 'description']) | map | `{ "_": [ "", "", "" ], "all-all": [ -1, -1, "-1", "All protocols" ], "all-icmp": [ -1, -1, "icmp", "All IPV4 ICMP" ], "all-ipv6-icmp": [ -1, -1, 58, "All IPV6 ICMP" ], "all-tcp": [ 0, 65535, "tcp", "All TCP ports" ], "all-udp": [ 0, 65535, "udp", "All UDP ports" ], "carbon-admin-tcp": [ 2004, 2004, "tcp", "Carbon admin" ], "carbon-gui-udp": [ 8081, 8081, "tcp", "Carbon GUI" ], "carbon-line-in-tcp": [ 2003, 2003, "tcp", "Carbon line-in" ], "carbon-line-in-udp": [ 2003, 2003, "udp", "Carbon line-in" ], "carbon-pickle-tcp": [ 2013, 2013, "tcp", "Carbon pickle" ], "carbon-pickle-udp": [ 2013, 2013, "udp", "Carbon pickle" ], "cassandra-clients-tcp": [ 9042, 9042, "tcp", "Cassandra clients" ], "cassandra-jmx-tcp": [ 7199, 7199, "tcp", "JMX" ], "cassandra-thrift-clients-tcp": [ 9160, 9160, "tcp", "Cassandra Thrift clients" ], "consul-cli-rpc-tcp": [ 8400, 8400, "tcp", "Consul CLI RPC" ], "consul-dns-tcp": [ 8600, 8600, "tcp", "Consul DNS" ], "consul-dns-udp": [ 8600, 8600, "udp", "Consul DNS" ], "consul-serf-lan-tcp": [ 8301, 8301, "tcp", "Serf LAN" ], "consul-serf-lan-udp": [ 8301, 8301, "udp", "Serf LAN" ], "consul-serf-wan-tcp": [ 8302, 8302, "tcp", "Serf WAN" ], "consul-serf-wan-udp": [ 8302, 8302, "udp", "Serf WAN" ], "consul-tcp": [ 8300, 8300, "tcp", "Consul server" ], "consul-webui-tcp": [ 8500, 8500, "tcp", "Consul web UI" ], "dns-tcp": [ 53, 53, "tcp", "DNS" ], "dns-udp": [ 53, 53, "udp", "DNS" ], "docker-swarm-mngmt-tcp": [ 2377, 2377, "tcp", "Docker Swarm cluster management" ], "docker-swarm-node-tcp": [ 7946, 7946, "tcp", "Docker Swarm node" ], "docker-swarm-node-udp": [ 7946, 7946, "udp", "Docker Swarm node" ], "docker-swarm-overlay-udp": [ 4789, 4789, "udp", "Docker Swarm Overlay Network Traffic" ], "elasticsearch-java-tcp": [ 9300, 9300, "tcp", "Elasticsearch Java interface" ], "elasticsearch-rest-tcp": [ 9200, 9200, "tcp", "Elasticsearch REST interface" ], "http-80-tcp": [ 80, 80, "tcp", "HTTP" ], "http-8080-tcp": [ 8080, 8080, "tcp", "HTTP" ], "https-443-tcp": [ 443, 443, "tcp", "HTTPS" ], "ipsec-4500-udp": [ 4500, 4500, "udp", "IPSEC NAT-T" ], "ipsec-500-udp": [ 500, 500, "udp", "IPSEC ISAKMP" ], "kafka-broker-tcp": [ 9092, 9092, "tcp", "Kafka broker 0.8.2+" ], "ldaps-tcp": [ 636, 636, "tcp", "LDAPS" ], "memcached-tcp": [ 11211, 11211, "tcp", "Memcached" ], "mssql-analytics-tcp": [ 2383, 2383, "tcp", "MSSQL Analytics" ], "mssql-broker-tcp": [ 4022, 4022, "tcp", "MSSQL Broker" ], "mssql-tcp": [ 1433, 1433, "tcp", "MSSQL Server" ], "mssql-udp": [ 1434, 1434, "udp", "MSSQL Browser" ], "mysql-tcp": [ 3306, 3306, "tcp", "MySQL/Aurora" ], "nfs-tcp": [ 2049, 2049, "tcp", "NFS/EFS" ], "nomad-http-tcp": [ 4646, 4646, "tcp", "Nomad HTTP" ], "nomad-rpc-tcp": [ 4647, 4647, "tcp", "Nomad RPC" ], "nomad-serf-tcp": [ 4648, 4648, "tcp", "Serf" ], "nomad-serf-udp": [ 4648, 4648, "udp", "Serf" ], "ntp-udp": [ 123, 123, "udp", "NTP" ], "openvpn-https-tcp": [ 443, 443, "tcp", "OpenVPN" ], "openvpn-tcp": [ 943, 943, "tcp", "OpenVPN" ], "openvpn-udp": [ 1194, 1194, "udp", "OpenVPN" ], "oracle-db-tcp": [ 1521, 1521, "tcp", "Oracle" ], "postgresql-tcp": [ 5432, 5432, "tcp", "PostgreSQL" ], "puppet-tcp": [ 8140, 8140, "tcp", "Puppet" ], "rdp-tcp": [ 3389, 3389, "tcp", "Remote Desktop" ], "rdp-udp": [ 3389, 3389, "udp", "Remote Desktop" ], "redis-tcp": [ 6379, 6379, "tcp", "Redis" ], "redshift-tcp": [ 5439, 5439, "tcp", "Redshift" ], "splunk-clients-tcp": [ 8080, 8080, "tcp", "Splunk clients" ], "splunk-hec-tcp": [ 8088, 8088, "tcp", "Splunk HEC" ], "splunk-indexer-tcp": [ 9997, 9997, "tcp", "Splunk indexer" ], "splunk-splunkd-tcp": [ 8089, 8089, "tcp", "Splunkd" ], "squid-proxy-tcp": [ 3128, 3128, "tcp", "Squid default proxy" ], "ssh-tcp": [ 22, 22, "tcp", "SSH" ], "storm-nimbus-tcp": [ 6627, 6627, "tcp", "Nimbus" ], "storm-supervisor-tcp": [ 6700, 6703, "tcp", "Supervisor" ], "storm-ui-tcp": [ 8080, 8080, "tcp", "Storm UI" ], "web-jmx-tcp": [ 1099, 1099, "tcp", "JMX" ], "winrm-http-tcp": [ 5985, 5985, "tcp", "WinRM HTTP" ], "winrm-https-tcp": [ 5986, 5986, "tcp", "WinRM HTTPS" ], "zipkin-admin-query-tcp": [ 9901, 9901, "tcp", "Zipkin Admin port query" ], "zipkin-admin-tcp": [ 9990, 9990, "tcp", "Zipkin Admin port collector" ], "zipkin-admin-web-tcp": [ 9991, 9991, "tcp", "Zipkin Admin port web" ], "zipkin-query-tcp": [ 9411, 9411, "tcp", "Zipkin query port" ], "zipkin-web-tcp": [ 8080, 8080, "tcp", "Zipkin web port" ], "zookeeper-2181-tcp": [ 2181, 2181, "tcp", "Zookeeper" ], "zookeeper-2888-tcp": [ 2888, 2888, "tcp", "Zookeeper" ], "zookeeper-3888-tcp": [ 3888, 3888, "tcp", "Zookeeper" ], "zookeeper-jmx-tcp": [ 7199, 7199, "tcp", "JMX" ] }` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -21,10 +21,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/computed/README.md
+++ b/examples/computed/README.md
@@ -19,10 +19,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/disabled/README.md
+++ b/examples/disabled/README.md
@@ -21,6 +21,6 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_security_group_id | The ID of the security group |
+| this\_security\_group\_id | The ID of the security group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/dynamic/README.md
+++ b/examples/dynamic/README.md
@@ -21,10 +21,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -21,10 +21,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/http/main.tf
+++ b/examples/http/main.tf
@@ -37,7 +37,9 @@ module "http_sg" {
 module "http_mysql_1_sg" {
   source = "../../modules/http-80"
 
-  name        = "http-mysql-1"
+  name            = "http-mysql-1"
+  use_name_prefix = false
+
   description = "Security group with HTTP and MySQL ports open for everybody (IPv4 CIDR)"
   vpc_id      = "${data.aws_vpc.default.id}"
 

--- a/modules/_templates/main.tf
+++ b/modules/_templates/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/_templates/variables.tf
+++ b/modules/_templates/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/carbon-relay-ng/README.md
+++ b/modules/carbon-relay-ng/README.md
@@ -17,80 +17,81 @@ All automatic values **carbon-relay-ng module** is using are available [here](ht
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "carbon-line-in-tcp", "carbon-line-in-udp", "carbon-pickle-tcp", "carbon-pickle-udp", "carbon-gui-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/carbon-relay-ng/main.tf
+++ b/modules/carbon-relay-ng/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/carbon-relay-ng/variables.tf
+++ b/modules/carbon-relay-ng/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -17,80 +17,81 @@ All automatic values **cassandra module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "cassandra-clients-tcp", "cassandra-thrift-clients-tcp", "cassandra-jmx-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cassandra/main.tf
+++ b/modules/cassandra/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/cassandra/variables.tf
+++ b/modules/cassandra/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -17,80 +17,81 @@ All automatic values **consul module** is using are available [here](https://git
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "consul-tcp", "consul-cli-rpc-tcp", "consul-webui-tcp", "consul-dns-tcp", "consul-dns-udp", "consul-serf-lan-tcp", "consul-serf-lan-udp", "consul-serf-wan-tcp", "consul-serf-wan-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/consul/main.tf
+++ b/modules/consul/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/consul/variables.tf
+++ b/modules/consul/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/docker-swarm/README.md
+++ b/modules/docker-swarm/README.md
@@ -17,80 +17,81 @@ All automatic values **docker-swarm module** is using are available [here](https
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "docker-swarm-mngmt-tcp", "docker-swarm-node-tcp", "docker-swarm-node-udp", "docker-swarm-overlay-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/docker-swarm/main.tf
+++ b/modules/docker-swarm/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/docker-swarm/variables.tf
+++ b/modules/docker-swarm/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -17,80 +17,81 @@ All automatic values **elasticsearch module** is using are available [here](http
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "elasticsearch-rest-tcp", "elasticsearch-java-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/elasticsearch/main.tf
+++ b/modules/elasticsearch/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/elasticsearch/variables.tf
+++ b/modules/elasticsearch/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/http-80/README.md
+++ b/modules/http-80/README.md
@@ -17,80 +17,81 @@ All automatic values **http-80 module** is using are available [here](https://gi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "http-80-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/http-80/main.tf
+++ b/modules/http-80/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/http-80/variables.tf
+++ b/modules/http-80/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/https-443/README.md
+++ b/modules/https-443/README.md
@@ -17,80 +17,81 @@ All automatic values **https-443 module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "https-443-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/https-443/main.tf
+++ b/modules/https-443/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/https-443/variables.tf
+++ b/modules/https-443/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -17,80 +17,81 @@ All automatic values **ipsec-4500 module** is using are available [here](https:/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "ipsec-4500-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ipsec-4500/main.tf
+++ b/modules/ipsec-4500/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/ipsec-4500/variables.tf
+++ b/modules/ipsec-4500/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/ipsec-500/README.md
+++ b/modules/ipsec-500/README.md
@@ -17,80 +17,81 @@ All automatic values **ipsec-500 module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "ipsec-500-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ipsec-500/main.tf
+++ b/modules/ipsec-500/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/ipsec-500/variables.tf
+++ b/modules/ipsec-500/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -17,80 +17,81 @@ All automatic values **kafka module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "kafka-broker-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kafka/main.tf
+++ b/modules/kafka/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/kafka/variables.tf
+++ b/modules/kafka/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/ldaps/README.md
+++ b/modules/ldaps/README.md
@@ -17,80 +17,81 @@ All automatic values **ldaps module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "ldaps-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ldaps/main.tf
+++ b/modules/ldaps/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/ldaps/variables.tf
+++ b/modules/ldaps/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/memcached/README.md
+++ b/modules/memcached/README.md
@@ -17,80 +17,81 @@ All automatic values **memcached module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "memcached-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/memcached/main.tf
+++ b/modules/memcached/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/memcached/variables.tf
+++ b/modules/memcached/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -17,80 +17,81 @@ All automatic values **mssql module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "mssql-tcp", "mssql-udp", "mssql-analytics-tcp", "mssql-broker-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mssql/main.tf
+++ b/modules/mssql/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/mssql/variables.tf
+++ b/modules/mssql/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -17,80 +17,81 @@ All automatic values **mysql module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "mysql-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/nfs/README.md
+++ b/modules/nfs/README.md
@@ -17,80 +17,81 @@ All automatic values **nfs module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "nfs-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nfs/main.tf
+++ b/modules/nfs/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/nfs/variables.tf
+++ b/modules/nfs/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -17,80 +17,81 @@ All automatic values **nomad module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "nomad-http-tcp", "nomad-rpc-tcp", "nomad-serf-tcp", "nomad-serf-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nomad/main.tf
+++ b/modules/nomad/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/nomad/variables.tf
+++ b/modules/nomad/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/ntp/README.md
+++ b/modules/ntp/README.md
@@ -17,80 +17,81 @@ All automatic values **ntp module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "ntp-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ntp/main.tf
+++ b/modules/ntp/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/ntp/variables.tf
+++ b/modules/ntp/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -17,80 +17,81 @@ All automatic values **openvpn module** is using are available [here](https://gi
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "openvpn-udp", "openvpn-tcp", "openvpn-https-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/openvpn/main.tf
+++ b/modules/openvpn/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/openvpn/variables.tf
+++ b/modules/openvpn/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/oracle-db/README.md
+++ b/modules/oracle-db/README.md
@@ -17,80 +17,81 @@ All automatic values **oracle-db module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "oracle-db-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/oracle-db/main.tf
+++ b/modules/oracle-db/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/oracle-db/variables.tf
+++ b/modules/oracle-db/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -17,80 +17,81 @@ All automatic values **postgresql module** is using are available [here](https:/
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "postgresql-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/rdp/README.md
+++ b/modules/rdp/README.md
@@ -17,80 +17,81 @@ All automatic values **rdp module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "rdp-tcp", "rdp-udp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/rdp/main.tf
+++ b/modules/rdp/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/rdp/variables.tf
+++ b/modules/rdp/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -17,80 +17,81 @@ All automatic values **redis module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "redis-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/redshift/README.md
+++ b/modules/redshift/README.md
@@ -17,80 +17,81 @@ All automatic values **redshift module** is using are available [here](https://g
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "redshift-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/redshift/main.tf
+++ b/modules/redshift/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/redshift/variables.tf
+++ b/modules/redshift/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/splunk/README.md
+++ b/modules/splunk/README.md
@@ -17,80 +17,81 @@ All automatic values **splunk module** is using are available [here](https://git
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "splunk-indexer-tcp", "splunk-clients-tcp", "splunk-splunkd-tcp", "splunk-hec-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/splunk/main.tf
+++ b/modules/splunk/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/splunk/variables.tf
+++ b/modules/splunk/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/squid/README.md
+++ b/modules/squid/README.md
@@ -17,80 +17,81 @@ All automatic values **squid module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "squid-proxy-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/squid/main.tf
+++ b/modules/squid/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/squid/variables.tf
+++ b/modules/squid/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -17,80 +17,81 @@ All automatic values **ssh module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "ssh-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ssh/main.tf
+++ b/modules/ssh/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/ssh/variables.tf
+++ b/modules/ssh/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/storm/README.md
+++ b/modules/storm/README.md
@@ -17,80 +17,81 @@ All automatic values **storm module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "storm-nimbus-tcp", "storm-ui-tcp", "storm-supervisor-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/storm/main.tf
+++ b/modules/storm/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/storm/variables.tf
+++ b/modules/storm/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -17,80 +17,81 @@ All automatic values **web module** is using are available [here](https://github
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "http-80-tcp", "http-8080-tcp", "https-443-tcp", "web-jmx-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/web/variables.tf
+++ b/modules/web/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/winrm/README.md
+++ b/modules/winrm/README.md
@@ -17,80 +17,81 @@ All automatic values **winrm module** is using are available [here](https://gith
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "winrm-http-tcp", "winrm-https-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/winrm/main.tf
+++ b/modules/winrm/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/winrm/variables.tf
+++ b/modules/winrm/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/zipkin/README.md
+++ b/modules/zipkin/README.md
@@ -17,80 +17,81 @@ All automatic values **zipkin module** is using are available [here](https://git
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "zipkin-admin-tcp", "zipkin-admin-query-tcp", "zipkin-admin-web-tcp", "zipkin-query-tcp", "zipkin-web-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zipkin/main.tf
+++ b/modules/zipkin/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/zipkin/variables.tf
+++ b/modules/zipkin/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -17,80 +17,81 @@ All automatic values **zookeeper module** is using are available [here](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| auto_computed_egress_rules | List of computed egress rules to add automatically | list | `<list>` | no |
-| auto_computed_egress_with_self | List of maps defining computed egress rules with self to add automatically | list | `<list>` | no |
-| auto_computed_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_computed_ingress_with_self | List of maps defining computed ingress rules with self to add automatically | list | `<list>` | no |
-| auto_egress_rules | List of egress rules to add automatically | list | `<list>` | no |
-| auto_egress_with_self | List of maps defining egress rules with self to add automatically | list | `<list>` | no |
-| auto_ingress_rules | List of ingress rules to add automatically | list | `<list>` | no |
-| auto_ingress_with_self | List of maps defining ingress rules with self to add automatically | list | `<list>` | no |
-| auto_number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| auto_number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| auto_number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| auto_number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| computed_egress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `<list>` | no |
-| computed_egress_rules | List of computed egress rules to create by name | list | `<list>` | no |
-| computed_egress_with_cidr_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_ipv6_cidr_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_egress_with_self | List of computed egress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_egress_with_source_security_group_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| computed_ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `<list>` | no |
-| computed_ingress_rules | List of computed ingress rules to create by name | list | `<list>` | no |
-| computed_ingress_with_cidr_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_ipv6_cidr_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| computed_ingress_with_self | List of computed ingress rules to create where 'self' is defined | list | `<list>` | no |
-| computed_ingress_with_source_security_group_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| auto\_computed\_egress\_rules | List of computed egress rules to add automatically | list | `[]` | no |
+| auto\_computed\_egress\_with\_self | List of maps defining computed egress rules with self to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_rules | List of ingress rules to add automatically | list | `[]` | no |
+| auto\_computed\_ingress\_with\_self | List of maps defining computed ingress rules with self to add automatically | list | `[]` | no |
+| auto\_egress\_rules | List of egress rules to add automatically | list | `[ "all-all" ]` | no |
+| auto\_egress\_with\_self | List of maps defining egress rules with self to add automatically | list | `[]` | no |
+| auto\_ingress\_rules | List of ingress rules to add automatically | list | `[ "zookeeper-2181-tcp", "zookeeper-2888-tcp", "zookeeper-3888-tcp", "zookeeper-jmx-tcp" ]` | no |
+| auto\_ingress\_with\_self | List of maps defining ingress rules with self to add automatically | list | `[ { "rule": "all-all" } ]` | no |
+| auto\_number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| auto\_number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| computed\_egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| computed\_egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed egress rules | list | `[ "::/0" ]` | no |
+| computed\_egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | list | `[]` | no |
+| computed\_egress\_rules | List of computed egress rules to create by name | list | `[]` | no |
+| computed\_egress\_with\_cidr\_blocks | List of computed egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_ipv6\_cidr\_blocks | List of computed egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_egress\_with\_self | List of computed egress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_egress\_with\_source\_security\_group\_id | List of computed egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| computed\_ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | list | `[]` | no |
+| computed\_ingress\_rules | List of computed ingress rules to create by name | list | `[]` | no |
+| computed\_ingress\_with\_cidr\_blocks | List of computed ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_ipv6\_cidr\_blocks | List of computed ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| computed\_ingress\_with\_self | List of computed ingress rules to create where 'self' is defined | list | `[]` | no |
+| computed\_ingress\_with\_source\_security\_group\_id | List of computed ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | create | Whether to create security group and all rules | string | `true` | no |
 | description | Description of security group | string | `Security Group managed by Terraform` | no |
-| egress_cidr_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `<list>` | no |
-| egress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `<list>` | no |
-| egress_rules | List of egress rules to create by name | list | `<list>` | no |
-| egress_with_cidr_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| egress_with_ipv6_cidr_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| egress_with_self | List of egress rules to create where 'self' is defined | list | `<list>` | no |
-| egress_with_source_security_group_id | List of egress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
-| ingress_cidr_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_ipv6_cidr_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `<list>` | no |
-| ingress_prefix_list_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `<list>` | no |
-| ingress_rules | List of ingress rules to create by name | list | `<list>` | no |
-| ingress_with_cidr_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_ipv6_cidr_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `<list>` | no |
-| ingress_with_self | List of ingress rules to create where 'self' is defined | list | `<list>` | no |
-| ingress_with_source_security_group_id | List of ingress rules to create where 'source_security_group_id' is used | list | `<list>` | no |
+| egress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all egress rules | list | `[ "0.0.0.0/0" ]` | no |
+| egress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all egress rules | list | `[ "::/0" ]` | no |
+| egress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | list | `[]` | no |
+| egress\_rules | List of egress rules to create by name | list | `[]` | no |
+| egress\_with\_cidr\_blocks | List of egress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_ipv6\_cidr\_blocks | List of egress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| egress\_with\_self | List of egress rules to create where 'self' is defined | list | `[]` | no |
+| egress\_with\_source\_security\_group\_id | List of egress rules to create where 'source_security_group_id' is used | list | `[]` | no |
+| ingress\_cidr\_blocks | List of IPv4 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_ipv6\_cidr\_blocks | List of IPv6 CIDR ranges to use on all ingress rules | list | `[]` | no |
+| ingress\_prefix\_list\_ids | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | list | `[]` | no |
+| ingress\_rules | List of ingress rules to create by name | list | `[]` | no |
+| ingress\_with\_cidr\_blocks | List of ingress rules to create where 'cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_ipv6\_cidr\_blocks | List of ingress rules to create where 'ipv6_cidr_blocks' is used | list | `[]` | no |
+| ingress\_with\_self | List of ingress rules to create where 'self' is defined | list | `[]` | no |
+| ingress\_with\_source\_security\_group\_id | List of ingress rules to create where 'source_security_group_id' is used | list | `[]` | no |
 | name | Name of security group | string | - | yes |
-| number_of_computed_egress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
-| number_of_computed_egress_rules | Number of computed egress rules to create by name | string | `0` | no |
-| number_of_computed_egress_with_cidr_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_ipv6_cidr_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_egress_with_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_egress_with_source_security_group_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| number_of_computed_ingress_cidr_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_ipv6_cidr_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_prefix_list_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
-| number_of_computed_ingress_rules | Number of computed ingress rules to create by name | string | `0` | no |
-| number_of_computed_ingress_with_cidr_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_ipv6_cidr_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
-| number_of_computed_ingress_with_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
-| number_of_computed_ingress_with_source_security_group_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
-| tags | A mapping of tags to assign to security group | map | `<map>` | no |
-| vpc_id | ID of the VPC where to create security group | string | - | yes |
+| number\_of\_computed\_egress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | string | `0` | no |
+| number\_of\_computed\_egress\_rules | Number of computed egress rules to create by name | string | `0` | no |
+| number\_of\_computed\_egress\_with\_cidr\_blocks | Number of computed egress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks | Number of computed egress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_egress\_with\_self | Number of computed egress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_egress\_with\_source\_security\_group\_id | Number of computed egress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_cidr\_blocks | Number of IPv4 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_ipv6\_cidr\_blocks | Number of IPv6 CIDR ranges to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_prefix\_list\_ids | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | string | `0` | no |
+| number\_of\_computed\_ingress\_rules | Number of computed ingress rules to create by name | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_cidr\_blocks | Number of computed ingress rules to create where 'cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks | Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_self | Number of computed ingress rules to create where 'self' is defined | string | `0` | no |
+| number\_of\_computed\_ingress\_with\_source\_security\_group\_id | Number of computed ingress rules to create where 'source_security_group_id' is used | string | `0` | no |
+| tags | A mapping of tags to assign to security group | map | `{}` | no |
+| use\_name\_prefix | Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation | string | `true` | no |
+| vpc\_id | ID of the VPC where to create security group | string | - | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| this_security_group_description | The description of the security group |
-| this_security_group_id | The ID of the security group |
-| this_security_group_name | The name of the security group |
-| this_security_group_owner_id | The owner ID |
-| this_security_group_vpc_id | The VPC ID |
+| this\_security\_group\_description | The description of the security group |
+| this\_security\_group\_id | The ID of the security group |
+| this\_security\_group\_name | The name of the security group |
+| this\_security\_group\_owner\_id | The owner ID |
+| this\_security\_group\_vpc\_id | The VPC ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zookeeper/main.tf
+++ b/modules/zookeeper/main.tf
@@ -1,11 +1,12 @@
 module "sg" {
   source = "../../"
 
-  create      = "${var.create}"
-  name        = "${var.name}"
-  description = "${var.description}"
-  vpc_id      = "${var.vpc_id}"
-  tags        = "${var.tags}"
+  create          = "${var.create}"
+  name            = "${var.name}"
+  use_name_prefix = "${var.use_name_prefix}"
+  description     = "${var.description}"
+  vpc_id          = "${var.vpc_id}"
+  tags            = "${var.tags}"
 
   ##########
   # Ingress

--- a/modules/zookeeper/variables.tf
+++ b/modules/zookeeper/variables.tf
@@ -14,6 +14,11 @@ variable "name" {
   description = "Name of security group"
 }
 
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  default     = true
+}
+
 variable "description" {
   description = "Description of security group"
   default     = "Security Group managed by Terraform"


### PR DESCRIPTION
This addition allows upgrade of this module without recreation of existing security groups.

Example:
```
module "http_mysql_1_sg" {
  source = "terraform-aws-modules/security-group/aws//modules/http-80"

  name            = "my-web-1"
  use_name_prefix = false
  # ...
}
```

Ref: https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/92#issuecomment-444793744