### PR TITLE
add rabbitmq discovery epmd port 4369

### DIFF
--- a/modules/rabbitmq/auto_values.tf
+++ b/modules/rabbitmq/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = "list"
-  default     = ["rabbitmq-5671-tcp", "rabbitmq-5672-tcp", "rabbitmq-15672-tcp", "rabbitmq-25672-tcp"]
+  default     = ["rabbitmq-4369-tcp", "rabbitmq-5671-tcp", "rabbitmq-5672-tcp", "rabbitmq-15672-tcp", "rabbitmq-25672-tcp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/rules.tf
+++ b/rules.tf
@@ -103,6 +103,7 @@ variable "rules" {
     puppet-tcp = [8140, 8140, "tcp", "Puppet"]
 
     # RabbitMQ
+    rabbitmq-4369-tcp  = [4369, 4369, "tcp", "RabbitMQ epmd"]
     rabbitmq-5671-tcp  = [5671, 5671, "tcp", "RabbitMQ"]
     rabbitmq-5672-tcp  = [5672, 5672, "tcp", "RabbitMQ"]
     rabbitmq-15672-tcp = [15671, 15671, "tcp", "RabbitMQ"]
@@ -312,7 +313,7 @@ variable "auto_groups" {
     }
 
     rabbitmq = {
-      ingress_rules     = ["rabbitmq-5671-tcp", "rabbitmq-5672-tcp", "rabbitmq-15672-tcp", "rabbitmq-25672-tcp"]
+      ingress_rules     = ["rabbitmq-4369-tcp", "rabbitmq-5671-tcp", "rabbitmq-5672-tcp", "rabbitmq-15672-tcp", "rabbitmq-25672-tcp"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }


### PR DESCRIPTION
Added a rule for RabbitMQ discovery epmd port 4369, fixes #109 