### PR TITLE
Use correct output of vpc module in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,14 +112,14 @@ module "db_computed_sg" {
 
   ingress_cidr_blocks = ["10.10.0.0/16", "${data.aws_security_group.default.id}"]
 
-  computed_ingress_cidr_blocks = ["${module.vpc.vpc_id}"]
+  computed_ingress_cidr_blocks = ["${module.vpc.vpc_cidr_block}"]
   number_of_computed_ingress_cidr_blocks = 1
 }
 
 module "db_computed_merged_sg" {
   # omitted for brevity
 
-  computed_ingress_cidr_blocks = ["10.10.0.0/16", "${data.aws_security_group.default.id}", "${module.vpc.vpc_id}"]
+  computed_ingress_cidr_blocks = ["10.10.0.0/16", "${data.aws_security_group.default.id}", "${module.vpc.vpc_cidr_block}"]
   number_of_computed_ingress_cidr_blocks = 3
 }
 ```

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ module "db_computed_sg" {
 module "db_computed_merged_sg" {
   # omitted for brevity
 
-  computed_ingress_cidr_blocks = ["10.10.0.0/16", "${data.aws_security_group.default.id}", "${module.vpc.vpc_cidr_block}"]
-  number_of_computed_ingress_cidr_blocks = 3
+  computed_ingress_cidr_blocks = ["10.10.0.0/16", "${module.vpc.vpc_cidr_block}"]
+  number_of_computed_ingress_cidr_blocks = 2
 }
 ```
 


### PR DESCRIPTION
Fixes #112 

In the README, there are a couple of instances where it suggests that `computer_ingress_cidr_blocks` accepts a VPC ID. Naturally that makes no sense and I assume it's a simple typo. This PR ought to fix it. 