### PR TITLE
Create New Rules before Destorying Old Ones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,10 @@ resource "aws_security_group_rule" "ingress_rules" {
   from_port = var.rules[var.ingress_rules[count.index]][0]
   to_port   = var.rules[var.ingress_rules[count.index]][1]
   protocol  = var.rules[var.ingress_rules[count.index]][2]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Computed - Security group rules with "cidr_blocks" and it uses list of rules names


### PR DESCRIPTION
When `ingress_cidr_blocks` is updated, the old security group rules are dropped before new ones are created. This could result in a brief outage. Further discussion in https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/67
