### PR TITLE
adding input for sg id to just make rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This module aims to implement **ALL** combinations of arguments supported by AWS
 * Named rules ([see the rules here](https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/master/rules.tf))
 * Named groups of rules with ingress (inbound) and egress (outbound) ports open for common scenarios (eg, [ssh](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/ssh), [http-80](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/http-80), [mysql](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/mysql), see the whole list [here](https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/master/modules/README.md))
 * Conditionally create security group and all required security group rules ("single boolean switch").
+* Inputting security group ID and have the module create rules in that security group
 
 Ingress and egress rules can be configured in a variety of ways. See [inputs section](#inputs) for all supported arguments and [complete example](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/examples/complete) for the complete use-case.
 

--- a/main.tf
+++ b/main.tf
@@ -5,15 +5,17 @@ locals {
   this_sg_id = concat(
     aws_security_group.this.*.id,
     aws_security_group.this_name_prefix.*.id,
+    var.security_group_id == "" ? [] : [var.security_group_id],
     [""],
   )[0]
 }
+
 
 ##########################
 # Security group with name
 ##########################
 resource "aws_security_group" "this" {
-  count = var.create && false == var.use_name_prefix ? 1 : 0
+  count = var.create && false == var.use_name_prefix && var.security_group_id == "" ? 1 : 0
 
   name        = var.name
   description = var.description
@@ -31,7 +33,7 @@ resource "aws_security_group" "this" {
 # Security group with name_prefix
 #################################
 resource "aws_security_group" "this_name_prefix" {
-  count = var.create && var.use_name_prefix ? 1 : 0
+  count = var.create && var.use_name_prefix && var.security_group_id == "" ? 1 : 0
 
   name_prefix = "${var.name}-"
   description = var.description

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,11 @@ variable "create" {
   default     = true
 }
 
+variable "security_group_id" {
+  description = "ID of existing security group whose rules we will manage"
+  default     = ""
+}
+
 variable "vpc_id" {
   description = "ID of the VPC where to create security group"
   type        = string


### PR DESCRIPTION
# Description

This PR is to allow an input security group to so that only rules are associated with existing group. 

This is the same as [#80](https://github.com/terraform-aws-modules/terraform-aws-security-group/pull/80) but updated to tf12.  
