### PR TITLE
remove ipv6 cidr block from security group rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -477,7 +477,6 @@ resource "aws_security_group_rule" "egress_with_source_security_group_id" {
   type              = "egress"
 
   source_security_group_id = var.egress_with_source_security_group_id[count.index]["source_security_group_id"]
-  ipv6_cidr_blocks         = var.egress_ipv6_cidr_blocks
   prefix_list_ids          = var.egress_prefix_list_ids
   description = lookup(
     var.egress_with_source_security_group_id[count.index],
@@ -522,7 +521,6 @@ resource "aws_security_group_rule" "computed_egress_with_source_security_group_i
   type              = "egress"
 
   source_security_group_id = var.computed_egress_with_source_security_group_id[count.index]["source_security_group_id"]
-  ipv6_cidr_blocks         = var.egress_ipv6_cidr_blocks
   prefix_list_ids          = var.egress_prefix_list_ids
   description = lookup(
     var.computed_egress_with_source_security_group_id[count.index],


### PR DESCRIPTION
# Description

When adding security group egress rules, a ""::/0" rule is also added, jeopardising the rule, making it overly broad.
