### PR TITLE
update required aws provider version from 2.42 to 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ No issue is creating limit on this module.
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Inputs
 

--- a/modules/_templates/versions.tf
+++ b/modules/_templates/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -19,7 +19,7 @@ All automatic values **activemq module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/activemq/versions.tf
+++ b/modules/activemq/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/alertmanager/README.md
+++ b/modules/alertmanager/README.md
@@ -19,7 +19,7 @@ All automatic values **alertmanager module** is using are available [here](https
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/alertmanager/versions.tf
+++ b/modules/alertmanager/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/carbon-relay-ng/README.md
+++ b/modules/carbon-relay-ng/README.md
@@ -19,7 +19,7 @@ All automatic values **carbon-relay-ng module** is using are available [here](ht
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/carbon-relay-ng/versions.tf
+++ b/modules/carbon-relay-ng/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -19,7 +19,7 @@ All automatic values **cassandra module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/cassandra/versions.tf
+++ b/modules/cassandra/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -19,7 +19,7 @@ All automatic values **consul module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/consul/versions.tf
+++ b/modules/consul/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/docker-swarm/README.md
+++ b/modules/docker-swarm/README.md
@@ -19,7 +19,7 @@ All automatic values **docker-swarm module** is using are available [here](https
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/docker-swarm/versions.tf
+++ b/modules/docker-swarm/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -19,7 +19,7 @@ All automatic values **elasticsearch module** is using are available [here](http
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/grafana/README.md
+++ b/modules/grafana/README.md
@@ -19,7 +19,7 @@ All automatic values **grafana module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/grafana/versions.tf
+++ b/modules/grafana/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/graphite-statsd/README.md
+++ b/modules/graphite-statsd/README.md
@@ -19,7 +19,7 @@ All automatic values **graphite-statsd module** is using are available [here](ht
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/graphite-statsd/versions.tf
+++ b/modules/graphite-statsd/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/http-80/README.md
+++ b/modules/http-80/README.md
@@ -19,7 +19,7 @@ All automatic values **http-80 module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/http-80/versions.tf
+++ b/modules/http-80/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/http-8080/README.md
+++ b/modules/http-8080/README.md
@@ -19,7 +19,7 @@ All automatic values **http-8080 module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/http-8080/versions.tf
+++ b/modules/http-8080/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/https-443/README.md
+++ b/modules/https-443/README.md
@@ -19,7 +19,7 @@ All automatic values **https-443 module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/https-443/versions.tf
+++ b/modules/https-443/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/https-8443/README.md
+++ b/modules/https-8443/README.md
@@ -19,7 +19,7 @@ All automatic values **https-8443 module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/https-8443/versions.tf
+++ b/modules/https-8443/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -19,7 +19,7 @@ All automatic values **ipsec-4500 module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/ipsec-4500/versions.tf
+++ b/modules/ipsec-4500/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/ipsec-500/README.md
+++ b/modules/ipsec-500/README.md
@@ -19,7 +19,7 @@ All automatic values **ipsec-500 module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/ipsec-500/versions.tf
+++ b/modules/ipsec-500/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -19,7 +19,7 @@ All automatic values **kafka module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/kafka/versions.tf
+++ b/modules/kafka/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/kibana/README.md
+++ b/modules/kibana/README.md
@@ -19,7 +19,7 @@ All automatic values **kibana module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/kibana/versions.tf
+++ b/modules/kibana/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/kubernetes-api/README.md
+++ b/modules/kubernetes-api/README.md
@@ -19,7 +19,7 @@ All automatic values **kubernetes-api module** is using are available [here](htt
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/kubernetes-api/versions.tf
+++ b/modules/kubernetes-api/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/ldaps/README.md
+++ b/modules/ldaps/README.md
@@ -19,7 +19,7 @@ All automatic values **ldaps module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/ldaps/versions.tf
+++ b/modules/ldaps/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -19,7 +19,7 @@ All automatic values **logstash module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/logstash/versions.tf
+++ b/modules/logstash/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/memcached/README.md
+++ b/modules/memcached/README.md
@@ -19,7 +19,7 @@ All automatic values **memcached module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/memcached/versions.tf
+++ b/modules/memcached/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/minio/README.md
+++ b/modules/minio/README.md
@@ -19,7 +19,7 @@ All automatic values **minio module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/minio/versions.tf
+++ b/modules/minio/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/mongodb/README.md
+++ b/modules/mongodb/README.md
@@ -19,7 +19,7 @@ All automatic values **mongodb module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/mongodb/versions.tf
+++ b/modules/mongodb/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -19,7 +19,7 @@ All automatic values **mssql module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -19,7 +19,7 @@ All automatic values **mysql module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/nfs/README.md
+++ b/modules/nfs/README.md
@@ -19,7 +19,7 @@ All automatic values **nfs module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/nfs/versions.tf
+++ b/modules/nfs/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -19,7 +19,7 @@ All automatic values **nomad module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/nomad/versions.tf
+++ b/modules/nomad/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/ntp/README.md
+++ b/modules/ntp/README.md
@@ -19,7 +19,7 @@ All automatic values **ntp module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/ntp/versions.tf
+++ b/modules/ntp/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -19,7 +19,7 @@ All automatic values **openvpn module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/openvpn/versions.tf
+++ b/modules/openvpn/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/oracle-db/README.md
+++ b/modules/oracle-db/README.md
@@ -19,7 +19,7 @@ All automatic values **oracle-db module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/oracle-db/versions.tf
+++ b/modules/oracle-db/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -19,7 +19,7 @@ All automatic values **postgresql module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -19,7 +19,7 @@ All automatic values **prometheus module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/prometheus/versions.tf
+++ b/modules/prometheus/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/puppet/README.md
+++ b/modules/puppet/README.md
@@ -19,7 +19,7 @@ All automatic values **puppet module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/puppet/versions.tf
+++ b/modules/puppet/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -19,7 +19,7 @@ All automatic values **rabbitmq module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/rabbitmq/versions.tf
+++ b/modules/rabbitmq/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/rdp/README.md
+++ b/modules/rdp/README.md
@@ -19,7 +19,7 @@ All automatic values **rdp module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/rdp/versions.tf
+++ b/modules/rdp/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -19,7 +19,7 @@ All automatic values **redis module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/redshift/README.md
+++ b/modules/redshift/README.md
@@ -19,7 +19,7 @@ All automatic values **redshift module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/redshift/versions.tf
+++ b/modules/redshift/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -19,7 +19,7 @@ All automatic values **solr module** is using are available [here](https://githu
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/solr/versions.tf
+++ b/modules/solr/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/splunk/README.md
+++ b/modules/splunk/README.md
@@ -19,7 +19,7 @@ All automatic values **splunk module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/splunk/versions.tf
+++ b/modules/splunk/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/squid/README.md
+++ b/modules/squid/README.md
@@ -19,7 +19,7 @@ All automatic values **squid module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/squid/versions.tf
+++ b/modules/squid/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -19,7 +19,7 @@ All automatic values **ssh module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/ssh/versions.tf
+++ b/modules/ssh/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/storm/README.md
+++ b/modules/storm/README.md
@@ -19,7 +19,7 @@ All automatic values **storm module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/storm/versions.tf
+++ b/modules/storm/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -19,7 +19,7 @@ All automatic values **web module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/web/versions.tf
+++ b/modules/web/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/winrm/README.md
+++ b/modules/winrm/README.md
@@ -19,7 +19,7 @@ All automatic values **winrm module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/winrm/versions.tf
+++ b/modules/winrm/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/zipkin/README.md
+++ b/modules/zipkin/README.md
@@ -19,7 +19,7 @@ All automatic values **zipkin module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/zipkin/versions.tf
+++ b/modules/zipkin/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -19,7 +19,7 @@ All automatic values **zookeeper module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.6, < 0.14 |
-| aws | ~> 2.42 |
+| aws | ~> 3.0 |
 
 ## Providers
 

--- a/modules/zookeeper/versions.tf
+++ b/modules/zookeeper/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 2.42"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
## Description
Updated required AWS provider version

## Motivation and Context
We're trying to upgrade our providers, but since this module specifies `~> 2.42` we can't. This will fix #182.

## Breaking Changes
Not sure

## How Has This Been Tested?
It hasn't - working on it now, but we use this module as part of some of our custom modules, so getting `tf init` running is a bit involved...