### PR TITLE
feat: Allow Custom 'Name' Tag For SG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,10 +21,10 @@ resource "aws_security_group" "this" {
   revoke_rules_on_delete = var.revoke_rules_on_delete
 
   tags = merge(
-    var.tags,
     {
       "Name" = format("%s", var.name)
     },
+    var.tags,
   )
 }
 
@@ -40,10 +40,10 @@ resource "aws_security_group" "this_name_prefix" {
   revoke_rules_on_delete = var.revoke_rules_on_delete
 
   tags = merge(
-    var.tags,
     {
       "Name" = format("%s", var.name)
     },
+    var.tags, 
   )
 
   lifecycle {


### PR DESCRIPTION
## Description

There are some use-cases  where we need to set custom 'Name' tag for Security Group. 
Eg: https://aws.amazon.com/blogs/security/how-to-automatically-update-your-security-groups-for-amazon-cloudfront-and-aws-waf-by-using-aws-lambda/

Above lambda script identify Msgs by looking at the name tag which needs to be set 'cloudfront_g / cloudfront_r'. Currently this is not possible as merge() function will give the second argument precedence over the first one.

### From https://www.terraform.io/docs/configuration/functions/merge.html ###
If more than one given map or object defines the same key or attribute, then the one that is later in the argument sequence takes precedence.

## Motivation and Context

Allow Custom Name Tags

## Breaking Changes
None
## How Has This Been Tested?
Tested locally by changing order in merge argument.