### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,6 @@ repos:
       - id: terraform_fmt
       - id: terraform_docs
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ No Modules.
 
 | Name |
 |------|
-| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/security_group) |
 | [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/security_group_rule) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/security_group) |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ No issue is creating limit on this module.
 |------|---------|
 | aws | >= 2.42 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/security_group) |
+| [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/2.42/docs/resources/security_group_rule) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -229,7 +240,6 @@ No issue is creating limit on this module.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,6 +27,23 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| complete_sg | ../../ |  |
+| fixed_name_sg | ../../ |  |
+| ipv4_ipv6_example | ../../ |  |
+| main_sg | ../../ |  |
+| vpc | terraform-aws-modules/vpc/aws |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -40,5 +57,4 @@ No input.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/computed/README.md
+++ b/examples/computed/README.md
@@ -25,6 +25,20 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| http_sg | ../../modules/https-443 |  |
+| mysql_sg | ../../modules/mysql |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -38,5 +52,4 @@ No input.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/disabled/README.md
+++ b/examples/disabled/README.md
@@ -27,6 +27,20 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| complete_sg_disabled | ../../ |  |
+| http_sg_disabled | ../../modules/http-80 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -36,5 +50,4 @@ No input.
 | Name | Description |
 |------|-------------|
 | this\_security\_group\_id | The ID of the security group |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/dynamic/README.md
+++ b/examples/dynamic/README.md
@@ -27,6 +27,19 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| http_sg | ../../modules/http-80 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -40,5 +53,4 @@ No input.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -27,6 +27,23 @@ No requirements.
 |------|---------|
 | aws | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| http_mysql_1_sg | ../../modules/http-80 |  |
+| http_mysql_2_sg | ../../modules/http-80 |  |
+| http_sg | ../../modules/http-80 |  |
+| http_with_egress_minimal_sg | ../../modules/http-80 |  |
+| http_with_egress_sg | ../../modules/http-80 |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+
 ## Inputs
 
 No input.
@@ -40,5 +57,4 @@ No input.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -25,6 +25,16 @@ All automatic values **activemq module** is using are available [here](https://g
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/alertmanager/README.md
+++ b/modules/alertmanager/README.md
@@ -25,6 +25,16 @@ All automatic values **alertmanager module** is using are available [here](https
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/carbon-relay-ng/README.md
+++ b/modules/carbon-relay-ng/README.md
@@ -25,6 +25,16 @@ All automatic values **carbon-relay-ng module** is using are available [here](ht
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -25,6 +25,16 @@ All automatic values **cassandra module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -25,6 +25,16 @@ All automatic values **consul module** is using are available [here](https://git
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/docker-swarm/README.md
+++ b/modules/docker-swarm/README.md
@@ -25,6 +25,16 @@ All automatic values **docker-swarm module** is using are available [here](https
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -25,6 +25,16 @@ All automatic values **elasticsearch module** is using are available [here](http
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/grafana/README.md
+++ b/modules/grafana/README.md
@@ -25,6 +25,16 @@ All automatic values **grafana module** is using are available [here](https://gi
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/graphite-statsd/README.md
+++ b/modules/graphite-statsd/README.md
@@ -25,6 +25,16 @@ All automatic values **graphite-statsd module** is using are available [here](ht
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/http-80/README.md
+++ b/modules/http-80/README.md
@@ -25,6 +25,16 @@ All automatic values **http-80 module** is using are available [here](https://gi
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/http-8080/README.md
+++ b/modules/http-8080/README.md
@@ -25,6 +25,16 @@ All automatic values **http-8080 module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/https-443/README.md
+++ b/modules/https-443/README.md
@@ -25,6 +25,16 @@ All automatic values **https-443 module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/https-8443/README.md
+++ b/modules/https-8443/README.md
@@ -25,6 +25,16 @@ All automatic values **https-8443 module** is using are available [here](https:/
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -25,6 +25,16 @@ All automatic values **ipsec-4500 module** is using are available [here](https:/
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ipsec-500/README.md
+++ b/modules/ipsec-500/README.md
@@ -25,6 +25,16 @@ All automatic values **ipsec-500 module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -25,6 +25,16 @@ All automatic values **kafka module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kibana/README.md
+++ b/modules/kibana/README.md
@@ -25,6 +25,16 @@ All automatic values **kibana module** is using are available [here](https://git
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/kubernetes-api/README.md
+++ b/modules/kubernetes-api/README.md
@@ -25,6 +25,16 @@ All automatic values **kubernetes-api module** is using are available [here](htt
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ldap/README.md
+++ b/modules/ldap/README.md
@@ -25,6 +25,16 @@ All automatic values **ldap module** is using are available [here](https://githu
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ldaps/README.md
+++ b/modules/ldaps/README.md
@@ -25,6 +25,16 @@ All automatic values **ldaps module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -25,6 +25,16 @@ All automatic values **logstash module** is using are available [here](https://g
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/memcached/README.md
+++ b/modules/memcached/README.md
@@ -25,6 +25,16 @@ All automatic values **memcached module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/minio/README.md
+++ b/modules/minio/README.md
@@ -25,6 +25,16 @@ All automatic values **minio module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mongodb/README.md
+++ b/modules/mongodb/README.md
@@ -25,6 +25,16 @@ All automatic values **mongodb module** is using are available [here](https://gi
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -25,6 +25,16 @@ All automatic values **mssql module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -25,6 +25,16 @@ All automatic values **mysql module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nfs/README.md
+++ b/modules/nfs/README.md
@@ -25,6 +25,16 @@ All automatic values **nfs module** is using are available [here](https://github
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -25,6 +25,16 @@ All automatic values **nomad module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ntp/README.md
+++ b/modules/ntp/README.md
@@ -25,6 +25,16 @@ All automatic values **ntp module** is using are available [here](https://github
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -25,6 +25,16 @@ All automatic values **openvpn module** is using are available [here](https://gi
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/oracle-db/README.md
+++ b/modules/oracle-db/README.md
@@ -25,6 +25,16 @@ All automatic values **oracle-db module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -25,6 +25,16 @@ All automatic values **postgresql module** is using are available [here](https:/
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -25,6 +25,16 @@ All automatic values **prometheus module** is using are available [here](https:/
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/puppet/README.md
+++ b/modules/puppet/README.md
@@ -25,6 +25,16 @@ All automatic values **puppet module** is using are available [here](https://git
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -25,6 +25,16 @@ All automatic values **rabbitmq module** is using are available [here](https://g
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/rdp/README.md
+++ b/modules/rdp/README.md
@@ -25,6 +25,16 @@ All automatic values **rdp module** is using are available [here](https://github
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -25,6 +25,16 @@ All automatic values **redis module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/redshift/README.md
+++ b/modules/redshift/README.md
@@ -25,6 +25,16 @@ All automatic values **redshift module** is using are available [here](https://g
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -25,6 +25,16 @@ All automatic values **solr module** is using are available [here](https://githu
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/splunk/README.md
+++ b/modules/splunk/README.md
@@ -25,6 +25,16 @@ All automatic values **splunk module** is using are available [here](https://git
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/squid/README.md
+++ b/modules/squid/README.md
@@ -25,6 +25,16 @@ All automatic values **squid module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -25,6 +25,16 @@ All automatic values **ssh module** is using are available [here](https://github
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/storm/README.md
+++ b/modules/storm/README.md
@@ -25,6 +25,16 @@ All automatic values **storm module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -25,6 +25,16 @@ All automatic values **web module** is using are available [here](https://github
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/winrm/README.md
+++ b/modules/winrm/README.md
@@ -25,6 +25,16 @@ All automatic values **winrm module** is using are available [here](https://gith
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zipkin/README.md
+++ b/modules/zipkin/README.md
@@ -25,6 +25,16 @@ All automatic values **zipkin module** is using are available [here](https://git
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -25,6 +25,16 @@ All automatic values **zookeeper module** is using are available [here](https://
 
 No provider.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| sg | ../../ |  |
+
+## Resources
+
+No resources.
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -106,5 +116,4 @@ No provider.
 | this\_security\_group\_name | The name of the security group |
 | this\_security\_group\_owner\_id | The owner ID |
 | this\_security\_group\_vpc\_id | The VPC ID |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
