### PR TITLE
ci: Fix terraform-docs install

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64" | head -n1)" > terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "$(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64.tar.gz")" > terraform-docs.tar.gz && tar zxvf terraform-docs.tar.gz && sudo mv terraform-docs /usr/bin/
           curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
 
 


### PR DESCRIPTION
## Description
Fix install of terraform-docs

## Motivation and Context
Since v0.13.0, terraform-docs is distributed as a tarball.

This change modifies the terraform-docs install command to grab the latest tarball and unpack it correctly.

## Breaking Changes
None

## How Has This Been Tested?
This has been tested in a private fork of this module.

You should also see that it succeeds in the checks that run as a result of this PR>