### PR TITLE
feat: addition of ingress_with_prefix_list_ids and egress_with_prefix_list_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ No issue is creating limit on this module.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.42 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
@@ -179,21 +179,25 @@ No modules.
 | [aws_security_group_rule.computed_egress_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_egress_with_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_egress_with_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.computed_egress_with_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_egress_with_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_egress_with_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_ingress_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_ingress_with_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_ingress_with_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.computed_ingress_with_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_ingress_with_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.computed_ingress_with_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_with_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_with_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_with_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_with_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.egress_with_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_with_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_with_ipv6_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_with_prefix_list_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_with_self](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_with_source_security_group_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 
@@ -205,11 +209,13 @@ No modules.
 | <a name="input_computed_egress_rules"></a> [computed\_egress\_rules](#input\_computed\_egress\_rules) | List of computed egress rules to create by name | `list(string)` | `[]` | no |
 | <a name="input_computed_egress_with_cidr_blocks"></a> [computed\_egress\_with\_cidr\_blocks](#input\_computed\_egress\_with\_cidr\_blocks) | List of computed egress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
 | <a name="input_computed_egress_with_ipv6_cidr_blocks"></a> [computed\_egress\_with\_ipv6\_cidr\_blocks](#input\_computed\_egress\_with\_ipv6\_cidr\_blocks) | List of computed egress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_egress_with_prefix_list_ids"></a> [computed\_egress\_with\_prefix\_list\_ids](#input\_computed\_egress\_with\_prefix\_list\_ids) | List of computed egress rules to create where 'prefix\_list\_ids' is used only | `list(map(string))` | `[]` | no |
 | <a name="input_computed_egress_with_self"></a> [computed\_egress\_with\_self](#input\_computed\_egress\_with\_self) | List of computed egress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
 | <a name="input_computed_egress_with_source_security_group_id"></a> [computed\_egress\_with\_source\_security\_group\_id](#input\_computed\_egress\_with\_source\_security\_group\_id) | List of computed egress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
 | <a name="input_computed_ingress_rules"></a> [computed\_ingress\_rules](#input\_computed\_ingress\_rules) | List of computed ingress rules to create by name | `list(string)` | `[]` | no |
 | <a name="input_computed_ingress_with_cidr_blocks"></a> [computed\_ingress\_with\_cidr\_blocks](#input\_computed\_ingress\_with\_cidr\_blocks) | List of computed ingress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
 | <a name="input_computed_ingress_with_ipv6_cidr_blocks"></a> [computed\_ingress\_with\_ipv6\_cidr\_blocks](#input\_computed\_ingress\_with\_ipv6\_cidr\_blocks) | List of computed ingress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_ingress_with_prefix_list_ids"></a> [computed\_ingress\_with\_prefix\_list\_ids](#input\_computed\_ingress\_with\_prefix\_list\_ids) | List of computed ingress rules to create where 'prefix\_list\_ids' is used | `list(map(string))` | `[]` | no |
 | <a name="input_computed_ingress_with_self"></a> [computed\_ingress\_with\_self](#input\_computed\_ingress\_with\_self) | List of computed ingress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
 | <a name="input_computed_ingress_with_source_security_group_id"></a> [computed\_ingress\_with\_source\_security\_group\_id](#input\_computed\_ingress\_with\_source\_security\_group\_id) | List of computed ingress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create security group and all rules | `bool` | `true` | no |
@@ -221,25 +227,30 @@ No modules.
 | <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | List of egress rules to create by name | `list(string)` | `[]` | no |
 | <a name="input_egress_with_cidr_blocks"></a> [egress\_with\_cidr\_blocks](#input\_egress\_with\_cidr\_blocks) | List of egress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
 | <a name="input_egress_with_ipv6_cidr_blocks"></a> [egress\_with\_ipv6\_cidr\_blocks](#input\_egress\_with\_ipv6\_cidr\_blocks) | List of egress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_egress_with_prefix_list_ids"></a> [egress\_with\_prefix\_list\_ids](#input\_egress\_with\_prefix\_list\_ids) | List of egress rules to create where 'prefix\_list\_ids' is used only | `list(map(string))` | `[]` | no |
 | <a name="input_egress_with_self"></a> [egress\_with\_self](#input\_egress\_with\_self) | List of egress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
 | <a name="input_egress_with_source_security_group_id"></a> [egress\_with\_source\_security\_group\_id](#input\_egress\_with\_source\_security\_group\_id) | List of egress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
+| <a name="input_enable_prefix_lists_cross_over"></a> [enable\_prefix\_lists\_cross\_over](#input\_enable\_prefix\_lists\_cross\_over) | Instruct Terraform to create crossing over ingress and egress Security Group Rules that cover also the Prefix lists provided as input. | `bool` | `true` | no |
 | <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all ingress rules | `list(string)` | `[]` | no |
 | <a name="input_ingress_ipv6_cidr_blocks"></a> [ingress\_ipv6\_cidr\_blocks](#input\_ingress\_ipv6\_cidr\_blocks) | List of IPv6 CIDR ranges to use on all ingress rules | `list(string)` | `[]` | no |
 | <a name="input_ingress_prefix_list_ids"></a> [ingress\_prefix\_list\_ids](#input\_ingress\_prefix\_list\_ids) | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | `list(string)` | `[]` | no |
 | <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | List of ingress rules to create by name | `list(string)` | `[]` | no |
 | <a name="input_ingress_with_cidr_blocks"></a> [ingress\_with\_cidr\_blocks](#input\_ingress\_with\_cidr\_blocks) | List of ingress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
 | <a name="input_ingress_with_ipv6_cidr_blocks"></a> [ingress\_with\_ipv6\_cidr\_blocks](#input\_ingress\_with\_ipv6\_cidr\_blocks) | List of ingress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_ingress_with_prefix_list_ids"></a> [ingress\_with\_prefix\_list\_ids](#input\_ingress\_with\_prefix\_list\_ids) | List of ingress rules to create where 'prefix\_list\_ids' is used only | `list(map(string))` | `[]` | no |
 | <a name="input_ingress_with_self"></a> [ingress\_with\_self](#input\_ingress\_with\_self) | List of ingress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
 | <a name="input_ingress_with_source_security_group_id"></a> [ingress\_with\_source\_security\_group\_id](#input\_ingress\_with\_source\_security\_group\_id) | List of ingress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of security group - not required if create\_group is false | `string` | `null` | no |
 | <a name="input_number_of_computed_egress_rules"></a> [number\_of\_computed\_egress\_rules](#input\_number\_of\_computed\_egress\_rules) | Number of computed egress rules to create by name | `number` | `0` | no |
 | <a name="input_number_of_computed_egress_with_cidr_blocks"></a> [number\_of\_computed\_egress\_with\_cidr\_blocks](#input\_number\_of\_computed\_egress\_with\_cidr\_blocks) | Number of computed egress rules to create where 'cidr\_blocks' is used | `number` | `0` | no |
 | <a name="input_number_of_computed_egress_with_ipv6_cidr_blocks"></a> [number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks](#input\_number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks) | Number of computed egress rules to create where 'ipv6\_cidr\_blocks' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_with_prefix_list_ids"></a> [number\_of\_computed\_egress\_with\_prefix\_list\_ids](#input\_number\_of\_computed\_egress\_with\_prefix\_list\_ids) | Number of computed egress rules to create where 'prefix\_list\_ids' is used only | `number` | `0` | no |
 | <a name="input_number_of_computed_egress_with_self"></a> [number\_of\_computed\_egress\_with\_self](#input\_number\_of\_computed\_egress\_with\_self) | Number of computed egress rules to create where 'self' is defined | `number` | `0` | no |
 | <a name="input_number_of_computed_egress_with_source_security_group_id"></a> [number\_of\_computed\_egress\_with\_source\_security\_group\_id](#input\_number\_of\_computed\_egress\_with\_source\_security\_group\_id) | Number of computed egress rules to create where 'source\_security\_group\_id' is used | `number` | `0` | no |
 | <a name="input_number_of_computed_ingress_rules"></a> [number\_of\_computed\_ingress\_rules](#input\_number\_of\_computed\_ingress\_rules) | Number of computed ingress rules to create by name | `number` | `0` | no |
 | <a name="input_number_of_computed_ingress_with_cidr_blocks"></a> [number\_of\_computed\_ingress\_with\_cidr\_blocks](#input\_number\_of\_computed\_ingress\_with\_cidr\_blocks) | Number of computed ingress rules to create where 'cidr\_blocks' is used | `number` | `0` | no |
 | <a name="input_number_of_computed_ingress_with_ipv6_cidr_blocks"></a> [number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks](#input\_number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks) | Number of computed ingress rules to create where 'ipv6\_cidr\_blocks' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_with_prefix_list_ids"></a> [number\_of\_computed\_ingress\_with\_prefix\_list\_ids](#input\_number\_of\_computed\_ingress\_with\_prefix\_list\_ids) | Number of computed ingress rules to create where 'prefix\_list\_ids' is used | `number` | `0` | no |
 | <a name="input_number_of_computed_ingress_with_self"></a> [number\_of\_computed\_ingress\_with\_self](#input\_number\_of\_computed\_ingress\_with\_self) | Number of computed ingress rules to create where 'self' is defined | `number` | `0` | no |
 | <a name="input_number_of_computed_ingress_with_source_security_group_id"></a> [number\_of\_computed\_ingress\_with\_source\_security\_group\_id](#input\_number\_of\_computed\_ingress\_with\_source\_security\_group\_id) | Number of computed ingress rules to create where 'source\_security\_group\_id' is used | `number` | `0` | no |
 | <a name="input_revoke_rules_on_delete"></a> [revoke\_rules\_on\_delete](#input\_revoke\_rules\_on\_delete) | Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. Enable for EMR. | `bool` | `false` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -25,18 +25,18 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_complete_sg"></a> [complete\_sg](#module\_complete\_sg) | ../../ |  |
-| <a name="module_fixed_name_sg"></a> [fixed\_name\_sg](#module\_fixed\_name\_sg) | ../../ |  |
-| <a name="module_ipv4_ipv6_example"></a> [ipv4\_ipv6\_example](#module\_ipv4\_ipv6\_example) | ../../ |  |
-| <a name="module_main_sg"></a> [main\_sg](#module\_main\_sg) | ../../ |  |
-| <a name="module_only_rules"></a> [only\_rules](#module\_only\_rules) | ../../ |  |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws |  |
+| <a name="module_complete_sg"></a> [complete\_sg](#module\_complete\_sg) | ../../ | n/a |
+| <a name="module_fixed_name_sg"></a> [fixed\_name\_sg](#module\_fixed\_name\_sg) | ../../ | n/a |
+| <a name="module_ipv4_ipv6_example"></a> [ipv4\_ipv6\_example](#module\_ipv4\_ipv6\_example) | ../../ | n/a |
+| <a name="module_main_sg"></a> [main\_sg](#module\_main\_sg) | ../../ | n/a |
+| <a name="module_only_rules"></a> [only\_rules](#module\_only\_rules) | ../../ | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -50,10 +50,9 @@ module "main_sg" {
 module "complete_sg" {
   source = "../../"
 
-  name                           = "complete-sg"
-  description                    = "Security group with all available arguments set (this is just an example)"
-  vpc_id                         = data.aws_vpc.default.id
-  enable_prefix_lists_cross_over = false
+  name        = "complete-sg"
+  description = "Security group with all available arguments set (this is just an example)"
+  vpc_id      = data.aws_vpc.default.id
 
   tags = {
     Cash       = "king"
@@ -67,7 +66,7 @@ module "complete_sg" {
   ingress_ipv6_cidr_blocks = ["2001:db8::/64"]
 
   # Prefix list ids to use in all ingress rules in this module.
-  ingress_prefix_list_ids = ["pl-6da54004"]
+  # ingress_prefix_list_ids = ["pl-123456"]
   # Open for all CIDRs defined in ingress_cidr_blocks
   ingress_rules = ["https-443-tcp"]
 
@@ -196,42 +195,6 @@ module "complete_sg" {
 
   number_of_computed_ingress_with_self = 1
 
-
-  # Open for Prefix List Ids only (rule or from_port+to_port+protocol+description)
-  ingress_with_prefix_list_ids = [
-    {
-      rule = "nfs-tcp"
-    },
-    {
-      from_port   = 30
-      to_port     = 40
-      protocol    = 6
-      description = "Service name"
-      self        = true
-    },
-    {
-      from_port = 41
-      to_port   = 51
-      protocol  = 6
-      self      = true
-    }
-  ]
-
-  computed_ingress_with_prefix_list_ids = [
-    {
-      from_port   = 32
-      to_port     = 43
-      protocol    = 6
-      description = "Service name. VPC ID: ${module.vpc.vpc_id}"
-      self        = true
-    }
-  ]
-
-  number_of_computed_ingress_with_prefix_list_ids = 1
-
-  # Prefix list ids to use in all egress rules in this module.
-  egress_prefix_list_ids = ["pl-6da54004"]
-
   # Default CIDR blocks, which will be used for all egress rules in this module. Typically these are CIDR blocks of the VPC.
   # If this is not specified then no CIDR blocks will be used.
   egress_cidr_blocks = ["10.10.0.0/16"]
@@ -348,35 +311,76 @@ module "complete_sg" {
   ]
 
   number_of_computed_egress_with_self = 1
+}
+
+#################################################################################
+# Security group with ingress and egress prefix list ids without cross over ports
+#################################################################################
+module "prefix_lists_sg" {
+  source = "../../"
+
+  name        = "prefix-lists-sg"
+  description = "Security group with ingress and egress prefix list ids arguments"
+  vpc_id      = data.aws_vpc.default.id
+
+  enable_prefix_lists_cross_over = false
+
+  tags = {
+    Cash       = "king"
+    Department = "kingdom"
+  }
+
+  # Prefix list ids to use only in ingress prefix list ids attribute (since 'enable_prefix_lists_cross_over' is false).
+  ingress_prefix_list_ids = ["pl-6da54004"]
 
   # Open for Prefix List Ids only (rule or from_port+to_port+protocol+description)
+  ingress_with_prefix_list_ids = [
+    {
+      from_port = 1041
+      to_port   = 1051
+      protocol  = 6
+      description = "Service name"
+    }
+  ]
+
+  computed_ingress_with_prefix_list_ids = [
+    {
+      from_port   = 6662
+      to_port     = 6683
+      protocol    = 6
+      description = "Service name. VPC ID: ${module.vpc.vpc_id}"
+    }
+  ]
+
+  number_of_computed_ingress_with_prefix_list_ids = 1
+
+  # Prefix list ids to use in all egress rules in this module.
+  egress_prefix_list_ids = ["pl-6da54004"]
 
   egress_with_prefix_list_ids = [
     {
       rule = "nfs-tcp"
     },
     {
-      from_port   = 30
-      to_port     = 40
+      from_port   = 840
+      to_port     = 860
       protocol    = 6
       description = "Service name"
-      self        = true
     },
     {
-      from_port = 41
-      to_port   = 51
+      from_port = 941
+      to_port   = 951
       protocol  = 6
-      self      = true
+      description = "Service name again"
     }
   ]
 
   computed_egress_with_prefix_list_ids = [
     {
-      from_port   = 32
-      to_port     = 43
+      from_port   = 8732
+      to_port     = 8743
       protocol    = 6
       description = "Service name. VPC ID: ${module.vpc.vpc_id}"
-      self        = true
     }
   ]
 
@@ -466,4 +470,3 @@ module "only_rules" {
     },
   ]
 }
-

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -50,9 +50,10 @@ module "main_sg" {
 module "complete_sg" {
   source = "../../"
 
-  name        = "complete-sg"
-  description = "Security group with all available arguments set (this is just an example)"
-  vpc_id      = data.aws_vpc.default.id
+  name                           = "complete-sg"
+  description                    = "Security group with all available arguments set (this is just an example)"
+  vpc_id                         = data.aws_vpc.default.id
+  enable_prefix_lists_cross_over = false
 
   tags = {
     Cash       = "king"
@@ -66,7 +67,7 @@ module "complete_sg" {
   ingress_ipv6_cidr_blocks = ["2001:db8::/64"]
 
   # Prefix list ids to use in all ingress rules in this module.
-  # ingress_prefix_list_ids = ["pl-123456"]
+  ingress_prefix_list_ids = ["pl-6da54004"]
   # Open for all CIDRs defined in ingress_cidr_blocks
   ingress_rules = ["https-443-tcp"]
 
@@ -195,6 +196,42 @@ module "complete_sg" {
 
   number_of_computed_ingress_with_self = 1
 
+
+  # Open for Prefix List Ids only (rule or from_port+to_port+protocol+description)
+  ingress_with_prefix_list_ids = [
+    {
+      rule = "nfs-tcp"
+    },
+    {
+      from_port   = 30
+      to_port     = 40
+      protocol    = 6
+      description = "Service name"
+      self        = true
+    },
+    {
+      from_port = 41
+      to_port   = 51
+      protocol  = 6
+      self      = true
+    }
+  ]
+
+  computed_ingress_with_prefix_list_ids = [
+    {
+      from_port   = 32
+      to_port     = 43
+      protocol    = 6
+      description = "Service name. VPC ID: ${module.vpc.vpc_id}"
+      self        = true
+    }
+  ]
+
+  number_of_computed_ingress_with_prefix_list_ids = 1
+
+  # Prefix list ids to use in all egress rules in this module.
+  egress_prefix_list_ids = ["pl-6da54004"]
+
   # Default CIDR blocks, which will be used for all egress rules in this module. Typically these are CIDR blocks of the VPC.
   # If this is not specified then no CIDR blocks will be used.
   egress_cidr_blocks = ["10.10.0.0/16"]
@@ -311,6 +348,39 @@ module "complete_sg" {
   ]
 
   number_of_computed_egress_with_self = 1
+
+  # Open for Prefix List Ids only (rule or from_port+to_port+protocol+description)
+
+  egress_with_prefix_list_ids = [
+    {
+      rule = "nfs-tcp"
+    },
+    {
+      from_port   = 30
+      to_port     = 40
+      protocol    = 6
+      description = "Service name"
+      self        = true
+    },
+    {
+      from_port = 41
+      to_port   = 51
+      protocol  = 6
+      self      = true
+    }
+  ]
+
+  computed_egress_with_prefix_list_ids = [
+    {
+      from_port   = 32
+      to_port     = 43
+      protocol    = 6
+      description = "Service name. VPC ID: ${module.vpc.vpc_id}"
+      self        = true
+    }
+  ]
+
+  number_of_computed_egress_with_prefix_list_ids = 1
 }
 
 ######################################################

--- a/examples/computed/README.md
+++ b/examples/computed/README.md
@@ -23,14 +23,14 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_http_sg"></a> [http\_sg](#module\_http\_sg) | ../../modules/https-443 |  |
-| <a name="module_mysql_sg"></a> [mysql\_sg](#module\_mysql\_sg) | ../../modules/mysql |  |
+| <a name="module_http_sg"></a> [http\_sg](#module\_http\_sg) | ../../modules/https-443 | n/a |
+| <a name="module_mysql_sg"></a> [mysql\_sg](#module\_mysql\_sg) | ../../modules/mysql | n/a |
 
 ## Resources
 

--- a/examples/disabled/README.md
+++ b/examples/disabled/README.md
@@ -25,14 +25,14 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_complete_sg_disabled"></a> [complete\_sg\_disabled](#module\_complete\_sg\_disabled) | ../../ |  |
-| <a name="module_http_sg_disabled"></a> [http\_sg\_disabled](#module\_http\_sg\_disabled) | ../../modules/http-80 |  |
+| <a name="module_complete_sg_disabled"></a> [complete\_sg\_disabled](#module\_complete\_sg\_disabled) | ../../ | n/a |
+| <a name="module_http_sg_disabled"></a> [http\_sg\_disabled](#module\_http\_sg\_disabled) | ../../modules/http-80 | n/a |
 
 ## Resources
 

--- a/examples/dynamic/README.md
+++ b/examples/dynamic/README.md
@@ -25,13 +25,13 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_http_sg"></a> [http\_sg](#module\_http\_sg) | ../../modules/http-80 |  |
+| <a name="module_http_sg"></a> [http\_sg](#module\_http\_sg) | ../../modules/http-80 | n/a |
 
 ## Resources
 

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -25,17 +25,17 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_http_mysql_1_sg"></a> [http\_mysql\_1\_sg](#module\_http\_mysql\_1\_sg) | ../../modules/http-80 |  |
-| <a name="module_http_mysql_2_sg"></a> [http\_mysql\_2\_sg](#module\_http\_mysql\_2\_sg) | ../../modules/http-80 |  |
-| <a name="module_http_sg"></a> [http\_sg](#module\_http\_sg) | ../../modules/http-80 |  |
-| <a name="module_http_with_egress_minimal_sg"></a> [http\_with\_egress\_minimal\_sg](#module\_http\_with\_egress\_minimal\_sg) | ../../modules/http-80 |  |
-| <a name="module_http_with_egress_sg"></a> [http\_with\_egress\_sg](#module\_http\_with\_egress\_sg) | ../../modules/http-80 |  |
+| <a name="module_http_mysql_1_sg"></a> [http\_mysql\_1\_sg](#module\_http\_mysql\_1\_sg) | ../../modules/http-80 | n/a |
+| <a name="module_http_mysql_2_sg"></a> [http\_mysql\_2\_sg](#module\_http\_mysql\_2\_sg) | ../../modules/http-80 | n/a |
+| <a name="module_http_sg"></a> [http\_sg](#module\_http\_sg) | ../../modules/http-80 | n/a |
+| <a name="module_http_with_egress_minimal_sg"></a> [http\_with\_egress\_minimal\_sg](#module\_http\_with\_egress\_minimal\_sg) | ../../modules/http-80 | n/a |
+| <a name="module_http_with_egress_sg"></a> [http\_with\_egress\_sg](#module\_http\_with\_egress\_sg) | ../../modules/http-80 | n/a |
 
 ## Resources
 

--- a/examples/rules-only/README.md
+++ b/examples/rules-only/README.md
@@ -25,14 +25,14 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.56.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rules_one"></a> [rules\_one](#module\_rules\_one) | ../../ |  |
-| <a name="module_rules_two"></a> [rules\_two](#module\_rules\_two) | ../../ |  |
+| <a name="module_rules_one"></a> [rules\_one](#module\_rules\_one) | ../../ | n/a |
+| <a name="module_rules_two"></a> [rules\_two](#module\_rules\_two) | ../../ | n/a |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "computed_ingress_rules" {
 
   cidr_blocks      = var.ingress_cidr_blocks
   ipv6_cidr_blocks = var.ingress_ipv6_cidr_blocks
-  prefix_list_ids  = var.ingress_prefix_list_ids
+  prefix_list_ids  = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description      = var.rules[var.computed_ingress_rules[count.index]][3]
 
   from_port = var.rules[var.computed_ingress_rules[count.index]][0]
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
   type              = "ingress"
 
   source_security_group_id = var.ingress_with_source_security_group_id[count.index]["source_security_group_id"]
-  prefix_list_ids          = var.ingress_prefix_list_ids
+  prefix_list_ids          = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.ingress_with_source_security_group_id[count.index],
     "description",
@@ -139,7 +139,7 @@ resource "aws_security_group_rule" "computed_ingress_with_source_security_group_
   type              = "ingress"
 
   source_security_group_id = var.computed_ingress_with_source_security_group_id[count.index]["source_security_group_id"]
-  prefix_list_ids          = var.ingress_prefix_list_ids
+  prefix_list_ids          = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.computed_ingress_with_source_security_group_id[count.index],
     "description",
@@ -190,7 +190,7 @@ resource "aws_security_group_rule" "ingress_with_cidr_blocks" {
       join(",", var.ingress_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.ingress_with_cidr_blocks[count.index],
     "description",
@@ -229,7 +229,7 @@ resource "aws_security_group_rule" "computed_ingress_with_cidr_blocks" {
       join(",", var.ingress_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.computed_ingress_with_cidr_blocks[count.index],
     "description",
@@ -280,7 +280,7 @@ resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
       join(",", var.ingress_ipv6_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.ingress_with_ipv6_cidr_blocks[count.index],
     "description",
@@ -319,7 +319,7 @@ resource "aws_security_group_rule" "computed_ingress_with_ipv6_cidr_blocks" {
       join(",", var.ingress_ipv6_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.computed_ingress_with_ipv6_cidr_blocks[count.index],
     "description",
@@ -363,7 +363,7 @@ resource "aws_security_group_rule" "ingress_with_self" {
   type              = "ingress"
 
   self            = lookup(var.ingress_with_self[count.index], "self", true)
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.ingress_with_self[count.index],
     "description",
@@ -395,7 +395,7 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
   type              = "ingress"
 
   self            = lookup(var.computed_ingress_with_self[count.index], "self", true)
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.ingress_prefix_list_ids : null
   description = lookup(
     var.computed_ingress_with_self[count.index],
     "description",
@@ -420,7 +420,7 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
 }
 # Security group rules with "prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
-  count = var.create ? length(var.ingress_with_prefix_list_ids) : 0
+  count = var.create && length(var.ingress_prefix_list_ids) > 0 ? length(var.ingress_with_prefix_list_ids) : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -451,7 +451,7 @@ resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
 
 # Computed - Security group rules with "prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "computed_ingress_with_prefix_list_ids" {
-  count = var.create ? var.number_of_computed_ingress_with_prefix_list_ids : 0
+  count = var.create && length(var.ingress_prefix_list_ids) > 0 ? var.number_of_computed_ingress_with_prefix_list_ids : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -496,7 +496,7 @@ resource "aws_security_group_rule" "egress_rules" {
 
   cidr_blocks      = var.egress_cidr_blocks
   ipv6_cidr_blocks = var.egress_ipv6_cidr_blocks
-  prefix_list_ids  = var.egress_prefix_list_ids
+  prefix_list_ids  = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description      = var.rules[var.egress_rules[count.index]][3]
 
   from_port = var.rules[var.egress_rules[count.index]][0]
@@ -513,7 +513,7 @@ resource "aws_security_group_rule" "computed_egress_rules" {
 
   cidr_blocks      = var.egress_cidr_blocks
   ipv6_cidr_blocks = var.egress_ipv6_cidr_blocks
-  prefix_list_ids  = var.egress_prefix_list_ids
+  prefix_list_ids  = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description      = var.rules[var.computed_egress_rules[count.index]][3]
 
   from_port = var.rules[var.computed_egress_rules[count.index]][0]
@@ -532,7 +532,7 @@ resource "aws_security_group_rule" "egress_with_source_security_group_id" {
   type              = "egress"
 
   source_security_group_id = var.egress_with_source_security_group_id[count.index]["source_security_group_id"]
-  prefix_list_ids          = var.egress_prefix_list_ids
+  prefix_list_ids          = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.egress_with_source_security_group_id[count.index],
     "description",
@@ -576,7 +576,7 @@ resource "aws_security_group_rule" "computed_egress_with_source_security_group_i
   type              = "egress"
 
   source_security_group_id = var.computed_egress_with_source_security_group_id[count.index]["source_security_group_id"]
-  prefix_list_ids          = var.egress_prefix_list_ids
+  prefix_list_ids          = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.computed_egress_with_source_security_group_id[count.index],
     "description",
@@ -627,7 +627,7 @@ resource "aws_security_group_rule" "egress_with_cidr_blocks" {
       join(",", var.egress_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.egress_with_cidr_blocks[count.index],
     "description",
@@ -666,7 +666,7 @@ resource "aws_security_group_rule" "computed_egress_with_cidr_blocks" {
       join(",", var.egress_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.computed_egress_with_cidr_blocks[count.index],
     "description",
@@ -717,7 +717,7 @@ resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
       join(",", var.egress_ipv6_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.egress_with_ipv6_cidr_blocks[count.index],
     "description",
@@ -756,7 +756,7 @@ resource "aws_security_group_rule" "computed_egress_with_ipv6_cidr_blocks" {
       join(",", var.egress_ipv6_cidr_blocks),
     ),
   )
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.computed_egress_with_ipv6_cidr_blocks[count.index],
     "description",
@@ -800,7 +800,7 @@ resource "aws_security_group_rule" "egress_with_self" {
   type              = "egress"
 
   self            = lookup(var.egress_with_self[count.index], "self", true)
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.egress_with_self[count.index],
     "description",
@@ -832,7 +832,7 @@ resource "aws_security_group_rule" "computed_egress_with_self" {
   type              = "egress"
 
   self            = lookup(var.computed_egress_with_self[count.index], "self", true)
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = var.enable_prefix_lists_cross_over ? var.egress_prefix_list_ids : null
   description = lookup(
     var.computed_egress_with_self[count.index],
     "description",
@@ -858,12 +858,12 @@ resource "aws_security_group_rule" "computed_egress_with_self" {
 
 # Security group rules with "egress_prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
-  count = var.create ? length(var.egress_with_prefix_list_ids) : 0
+  count = var.create && length(var.egress_prefix_list_ids) > 0 ? length(var.egress_with_prefix_list_ids) : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  prefix_list_ids          = var.egress_prefix_list_ids
+  prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
     var.egress_with_prefix_list_ids[count.index],
     "description",
@@ -901,13 +901,12 @@ resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
 
 # Computed - Security group rules with "source_security_group_id", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "computed_egress_with_prefix_list_ids" {
-  count = var.create ? var.number_of_computed_egress_with_prefix_list_ids : 0
+  count = var.create && length(var.egress_prefix_list_ids) > 0 ? var.number_of_computed_egress_with_prefix_list_ids : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  source_security_group_id = var.computed_egress_with_prefix_list_ids[count.index]["source_security_group_id"]
-  prefix_list_ids          = var.egress_prefix_list_ids
+  prefix_list_ids = var.egress_prefix_list_ids
   description = lookup(
     var.computed_egress_with_prefix_list_ids[count.index],
     "description",

--- a/main.tf
+++ b/main.tf
@@ -418,6 +418,67 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
     var.rules[lookup(var.computed_ingress_with_self[count.index], "rule", "_")][2],
   )
 }
+# Security group rules with "prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
+resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
+  count = var.create ? length(var.ingress_with_prefix_list_ids) : 0
+
+  security_group_id = local.this_sg_id
+  type              = "ingress"
+
+  prefix_list_ids = var.ingress_prefix_list_ids
+  description = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "description",
+    "Ingress Rule",
+  )
+
+  from_port = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "from_port",
+    var.rules[lookup(var.ingress_with_prefix_list_ids[count.index], "rule", "_")][0],
+  )
+  to_port = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "to_port",
+    var.rules[lookup(var.ingress_with_prefix_list_ids[count.index], "rule", "_")][1],
+  )
+  protocol = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "protocol",
+    var.rules[lookup(var.ingress_with_prefix_list_ids[count.index], "rule", "_")][2],
+  )
+}
+
+# Computed - Security group rules with "prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
+resource "aws_security_group_rule" "computed_ingress_with_prefix_list_ids" {
+  count = var.create ? var.number_of_computed_ingress_with_prefix_list_ids : 0
+
+  security_group_id = local.this_sg_id
+  type              = "ingress"
+
+  prefix_list_ids = var.ingress_prefix_list_ids
+  description = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "description",
+    "Ingress Rule",
+  )
+
+  from_port = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "from_port",
+    var.rules[lookup(var.ingress_with_prefix_list_ids[count.index], "rule", "_")][0],
+  )
+  to_port = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "to_port",
+    var.rules[lookup(var.ingress_with_prefix_list_ids[count.index], "rule", "_")][1],
+  )
+  protocol = lookup(
+    var.ingress_with_prefix_list_ids[count.index],
+    "protocol",
+    var.rules[lookup(var.ingress_with_prefix_list_ids[count.index], "rule", "_")][2],
+  )
+}
 
 #################
 # End of ingress
@@ -792,6 +853,93 @@ resource "aws_security_group_rule" "computed_egress_with_self" {
     var.computed_egress_with_self[count.index],
     "protocol",
     var.rules[lookup(var.computed_egress_with_self[count.index], "rule", "_")][2],
+  )
+}
+
+# Security group rules with "egress_prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
+resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
+  count = var.create ? length(var.egress_with_prefix_list_ids) : 0
+
+  security_group_id = local.this_sg_id
+  type              = "egress"
+
+  prefix_list_ids          = var.egress_prefix_list_ids
+  description = lookup(
+    var.egress_with_prefix_list_ids[count.index],
+    "description",
+    "Egress Rule",
+  )
+
+  from_port = lookup(
+    var.egress_with_prefix_list_ids[count.index],
+    "from_port",
+    var.rules[lookup(
+      var.egress_with_prefix_list_ids[count.index],
+      "rule",
+      "_",
+    )][0],
+  )
+  to_port = lookup(
+    var.egress_with_prefix_list_ids[count.index],
+    "to_port",
+    var.rules[lookup(
+      var.egress_with_prefix_list_ids[count.index],
+      "rule",
+      "_",
+    )][1],
+  )
+  protocol = lookup(
+    var.egress_with_prefix_list_ids[count.index],
+    "protocol",
+    var.rules[lookup(
+      var.egress_with_prefix_list_ids[count.index],
+      "rule",
+      "_",
+    )][2],
+  )
+}
+
+# Computed - Security group rules with "source_security_group_id", but without "cidr_blocks", "self" or "source_security_group_id"
+resource "aws_security_group_rule" "computed_egress_with_prefix_list_ids" {
+  count = var.create ? var.number_of_computed_egress_with_prefix_list_ids : 0
+
+  security_group_id = local.this_sg_id
+  type              = "egress"
+
+  source_security_group_id = var.computed_egress_with_prefix_list_ids[count.index]["source_security_group_id"]
+  prefix_list_ids          = var.egress_prefix_list_ids
+  description = lookup(
+    var.computed_egress_with_prefix_list_ids[count.index],
+    "description",
+    "Egress Rule",
+  )
+
+  from_port = lookup(
+    var.computed_egress_with_prefix_list_ids[count.index],
+    "from_port",
+    var.rules[lookup(
+      var.computed_egress_with_prefix_list_ids[count.index],
+      "rule",
+      "_",
+    )][0],
+  )
+  to_port = lookup(
+    var.computed_egress_with_prefix_list_ids[count.index],
+    "to_port",
+    var.rules[lookup(
+      var.computed_egress_with_prefix_list_ids[count.index],
+      "rule",
+      "_",
+    )][1],
+  )
+  protocol = lookup(
+    var.computed_egress_with_prefix_list_ids[count.index],
+    "protocol",
+    var.rules[lookup(
+      var.computed_egress_with_prefix_list_ids[count.index],
+      "rule",
+      "_",
+    )][2],
   )
 }
 

--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/alertmanager/README.md
+++ b/modules/alertmanager/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/carbon-relay-ng/README.md
+++ b/modules/carbon-relay-ng/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/docker-swarm/README.md
+++ b/modules/docker-swarm/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/grafana/README.md
+++ b/modules/grafana/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/graphite-statsd/README.md
+++ b/modules/graphite-statsd/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/http-80/README.md
+++ b/modules/http-80/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/http-8080/README.md
+++ b/modules/http-8080/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/https-443/README.md
+++ b/modules/https-443/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/https-8443/README.md
+++ b/modules/https-8443/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/ipsec-500/README.md
+++ b/modules/ipsec-500/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/kibana/README.md
+++ b/modules/kibana/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/kubernetes-api/README.md
+++ b/modules/kubernetes-api/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/ldap/README.md
+++ b/modules/ldap/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/ldaps/README.md
+++ b/modules/ldaps/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/memcached/README.md
+++ b/modules/memcached/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/minio/README.md
+++ b/modules/minio/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/mongodb/README.md
+++ b/modules/mongodb/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/nfs/README.md
+++ b/modules/nfs/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/ntp/README.md
+++ b/modules/ntp/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/oracle-db/README.md
+++ b/modules/oracle-db/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/puppet/README.md
+++ b/modules/puppet/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/rdp/README.md
+++ b/modules/rdp/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/redshift/README.md
+++ b/modules/redshift/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/smtp-submission/README.md
+++ b/modules/smtp-submission/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/smtp/README.md
+++ b/modules/smtp/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/smtps/README.md
+++ b/modules/smtps/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/splunk/README.md
+++ b/modules/splunk/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/squid/README.md
+++ b/modules/squid/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/storm/README.md
+++ b/modules/storm/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/winrm/README.md
+++ b/modules/winrm/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/zipkin/README.md
+++ b/modules/zipkin/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -29,7 +29,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sg"></a> [sg](#module\_sg) | ../../ |  |
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
 
 ## Resources
 

--- a/variables.tf
+++ b/variables.tf
@@ -105,6 +105,11 @@ variable "ingress_prefix_list_ids" {
   type        = list(string)
   default     = []
 }
+variable "ingress_with_prefix_list_ids" {
+  description = "List of ingress rules to create where 'prefix_list_ids' is used only"
+  type        = list(map(string))
+  default     = []
+}
 
 ###################
 # Computed Ingress
@@ -135,6 +140,11 @@ variable "computed_ingress_with_ipv6_cidr_blocks" {
 
 variable "computed_ingress_with_source_security_group_id" {
   description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+variable "computed_ingress_with_prefix_list_ids" {
+  description = "List of computed ingress rules to create where 'prefix_list_ids' is used"
   type        = list(map(string))
   default     = []
 }
@@ -171,6 +181,11 @@ variable "number_of_computed_ingress_with_source_security_group_id" {
   type        = number
   default     = 0
 }
+variable "number_of_computed_ingress_with_prefix_list_ids" {
+  description = "Number of computed ingress rules to create where 'prefix_list_ids' is used"
+  type        = number
+  default     = 0
+}
 
 #########
 # Egress
@@ -201,6 +216,11 @@ variable "egress_with_ipv6_cidr_blocks" {
 
 variable "egress_with_source_security_group_id" {
   description = "List of egress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+variable "egress_with_prefix_list_ids" {
+  description = "List of egress rules to create where 'prefix_list_ids' is used only"
   type        = list(map(string))
   default     = []
 }
@@ -255,6 +275,11 @@ variable "computed_egress_with_source_security_group_id" {
   type        = list(map(string))
   default     = []
 }
+variable "computed_egress_with_prefix_list_ids" {
+  description = "List of computed egress rules to create where 'prefix_list_ids' is used only"
+  type        = list(map(string))
+  default     = []
+}
 
 ##################################
 # Number of computed egress rules
@@ -285,6 +310,11 @@ variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
 
 variable "number_of_computed_egress_with_source_security_group_id" {
   description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  type        = number
+  default     = 0
+}
+variable "computed_egress_with_prefix_list_ids" {
+  description = "Number of computed egress rules to create where 'prefix_list_ids' is used only"
   type        = number
   default     = 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,11 @@ variable "revoke_rules_on_delete" {
   type        = bool
   default     = false
 }
+variable "enable_prefix_lists_cross_over" {
+  description = "Instruct Terraform to create crossing over ingress and egress Security Group Rules that cover also the Prefix lists provided as input."
+  type        = bool
+  default     = true
+}
 
 variable "tags" {
   description = "A mapping of tags to assign to security group"
@@ -87,6 +92,11 @@ variable "ingress_with_source_security_group_id" {
   type        = list(map(string))
   default     = []
 }
+variable "ingress_with_prefix_list_ids" {
+  description = "List of ingress rules to create where 'prefix_list_ids' is used only"
+  type        = list(map(string))
+  default     = []
+}
 
 variable "ingress_cidr_blocks" {
   description = "List of IPv4 CIDR ranges to use on all ingress rules"
@@ -103,11 +113,6 @@ variable "ingress_ipv6_cidr_blocks" {
 variable "ingress_prefix_list_ids" {
   description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules"
   type        = list(string)
-  default     = []
-}
-variable "ingress_with_prefix_list_ids" {
-  description = "List of ingress rules to create where 'prefix_list_ids' is used only"
-  type        = list(map(string))
   default     = []
 }
 
@@ -313,7 +318,7 @@ variable "number_of_computed_egress_with_source_security_group_id" {
   type        = number
   default     = 0
 }
-variable "computed_egress_with_prefix_list_ids" {
+variable "number_of_computed_egress_with_prefix_list_ids" {
   description = "Number of computed egress rules to create where 'prefix_list_ids' is used only"
   type        = number
   default     = 0


### PR DESCRIPTION
## Description
This feature aims at allowing the module to provision SG Rules by specifying explicitly the ingress or ingress rules with prefix lists. It also allows to unset a new variable enable_prefix_lists_cross_over which drives whether there should be cross over flow openings between the inputs (self, cidr blocks, or security groups) and the prefix lists.

## Motivation and Context
This will allow to have better control over the ingress / egress rules that can be created that rely on prefix_lists in conjunction with the other inputs (self, source sg or cidr blocks)
This feature has been inspired from this issue [https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/224](url)

## Breaking Changes
Nope this change assures backward compatibility since new variables were created.
In addition, the default value of enable_prefix_lists_cross_over is set to true in order to perpetuate the old behaviour.

## How Has This Been Tested?
- [ X ] I have tested and validated these changes using one or more of the provided `examples/*` projects
The feature has been tested according to the update of the complete sg example.
From a pure feature implementation perspective, the code works. However, I hit the following error which is for me a Terraform bug (since the ingress rule is successfully created on AWS) :

Error: [WARN] A duplicate Security Group rule was found on (sg-03f7058fc9696e5b0). This may be
│ a side effect of a now-fixed Terraform issue causing two security groups with
│ identical attributes but different source_security_group_ids to overwrite each
│ other in the state. See https://github.com/hashicorp/terraform/pull/2376 for more
│ information and instructions for recovery. Error: InvalidPermission.Duplicate: the specified rule "peer: pl-6da54004, TCP, from port: 2049, to port: 2049, ALLOW" already exists
│ 	status code: 400, request id: 6f21e4aa-8861-4d25-8638-5b97582a79de
│
│   with module.complete_sg.aws_security_group_rule.ingress_with_prefix_list_ids[0],
│   on ../../main.tf line 422, in resource "aws_security_group_rule" "ingress_with_prefix_list_ids":
│  422: resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
│

Unfortunately, I don't know how to move forward with the Terraform bug since it looks like it's an issue in persisting the creation of the Ingress rule on the tf state itself.

I'd be happy to know more about it and collaborate on it to solve it.

Thanks in advance.

Bests.
