### PR TITLE
feat: Move to using `for_each` for resource blocks where it is possible

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "this_name_prefix" {
 ###################################
 # Security group rules with "cidr_blocks" and it uses list of rules names
 resource "aws_security_group_rule" "ingress_rules" {
-  count = var.create ? length(var.ingress_rules) : 0
+  for_each = var.create ? toset(var.ingress_rules) : []
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -70,11 +70,11 @@ resource "aws_security_group_rule" "ingress_rules" {
   cidr_blocks      = var.ingress_cidr_blocks
   ipv6_cidr_blocks = var.ingress_ipv6_cidr_blocks
   prefix_list_ids  = var.ingress_prefix_list_ids
-  description      = var.rules[var.ingress_rules[count.index]][3]
+  description      = var.rules[each.value][3]
 
-  from_port = var.rules[var.ingress_rules[count.index]][0]
-  to_port   = var.rules[var.ingress_rules[count.index]][1]
-  protocol  = var.rules[var.ingress_rules[count.index]][2]
+  from_port = var.rules[each.value][0]
+  to_port   = var.rules[each.value][1]
+  protocol  = var.rules[each.value][2]
 }
 
 # Computed - Security group rules with "cidr_blocks" and it uses list of rules names
@@ -438,7 +438,7 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
 ##################################
 # Security group rules with "cidr_blocks" and it uses list of rules names
 resource "aws_security_group_rule" "egress_rules" {
-  count = var.create ? length(var.egress_rules) : 0
+  for_each = var.create ? toset(var.egress_rules) : []
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -446,11 +446,11 @@ resource "aws_security_group_rule" "egress_rules" {
   cidr_blocks      = var.egress_cidr_blocks
   ipv6_cidr_blocks = var.egress_ipv6_cidr_blocks
   prefix_list_ids  = var.egress_prefix_list_ids
-  description      = var.rules[var.egress_rules[count.index]][3]
+  description      = var.rules[each.value][3]
 
-  from_port = var.rules[var.egress_rules[count.index]][0]
-  to_port   = var.rules[var.egress_rules[count.index]][1]
-  protocol  = var.rules[var.egress_rules[count.index]][2]
+  from_port = var.rules[each.value][0]
+  to_port   = var.rules[each.value][1]
+  protocol  = var.rules[each.value][2]
 }
 
 # Computed - Security group rules with "cidr_blocks" and it uses list of rules names


### PR DESCRIPTION
## Description
Move the `aws_security_group_rule.ingress_rules` and `aws_security_group_rule.egress_rules` resource blocks to using the `for_each` meta-argument from the `count`.

## Motivation and Context
It is pretty widely understood that using the `count` meta-argument can cause churn ([ref](https://www.terraform.io/language/meta-arguments/count#when-to-use-for_each-instead-of-count)) in some contexts, such as the context in which this module is used.
This module cannot use `for_each` in every resource block, however the two resource blocks specified in the description can easily be converted to using the `for_each` meta-argument.

## Breaking Changes
This change does not break anything. However, it will cause churn when switching from an old `count`-based version of the module to a `for_each`-based version, because the resources are switching from being an ordered list (`sg_rule[0]`, `sg_rule[1]`, etc.) to a map (`sg_rule["all-all"]`, `sg_rule["ssh"]`, etc.).

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

I ran the `examples/complete` project. This created 44 resources as expected, including _some_ security group rules that are not numerically indexed:
```hcl
### This snippet is from the `terraform plan` command, but is given HCL highlighting for clarity

  # module.complete_sg.aws_security_group_rule.ingress_rules["https-443-tcp"] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = [
          + "10.10.0.0/16",
        ]
      + description              = "HTTPS"
      + from_port                = 443
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "2001:db8::/64",
        ]
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }
```

The region deployed into was `eu-west-1`, and all other resources were created as expected, as this PR does not interefere with their logic.
