### PR TITLE
feat: Add additional output security_group_arn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
+        exclude: '^modules/_templates/[^/]+$'
       - id: terraform_docs
         args:
           - '--args=--lockfile=false'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -9,7 +9,7 @@ repos:
         args:
           - '--args=--lockfile=false'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -160,13 +160,13 @@ No issue is creating limit on this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -258,6 +258,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -56,6 +56,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.complete_sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.complete_sg.security_group_id

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/examples/computed/README.md
+++ b/examples/computed/README.md
@@ -20,13 +20,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -50,6 +50,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/examples/computed/outputs.tf
+++ b/examples/computed/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.mysql_sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.mysql_sg.security_group_id

--- a/examples/computed/versions.tf
+++ b/examples/computed/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/examples/disabled/README.md
+++ b/examples/disabled/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -52,5 +52,6 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/disabled/outputs.tf
+++ b/examples/disabled/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.complete_sg_disabled.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.complete_sg_disabled.security_group_id

--- a/examples/disabled/versions.tf
+++ b/examples/disabled/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/examples/dynamic/README.md
+++ b/examples/dynamic/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -51,6 +51,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/examples/dynamic/outputs.tf
+++ b/examples/dynamic/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.http_sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.http_sg.security_group_id

--- a/examples/dynamic/versions.tf
+++ b/examples/dynamic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -55,6 +55,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/examples/http/outputs.tf
+++ b/examples/http/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.http_sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.http_sg.security_group_id

--- a/examples/http/versions.tf
+++ b/examples/http/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/examples/rules-only/README.md
+++ b/examples/rules-only/README.md
@@ -22,13 +22,13 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.29 |
 
 ## Modules
 
@@ -54,6 +54,8 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_service_one_security_group_arn"></a> [service\_one\_security\_group\_arn](#output\_service\_one\_security\_group\_arn) | The ARN of the security group for service one |
 | <a name="output_service_one_security_group_id"></a> [service\_one\_security\_group\_id](#output\_service\_one\_security\_group\_id) | The ID of the security group for service one |
+| <a name="output_service_tow_security_group_arn"></a> [service\_tow\_security\_group\_arn](#output\_service\_tow\_security\_group\_arn) | The ARN of the security group for service two |
 | <a name="output_service_two_security_group_id"></a> [service\_two\_security\_group\_id](#output\_service\_two\_security\_group\_id) | The ID of the security group for service two |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/rules-only/outputs.tf
+++ b/examples/rules-only/outputs.tf
@@ -1,6 +1,16 @@
+output "service_one_security_group_arn" {
+  description = "The ARN of the security group for service one"
+  value       = aws_security_group.service_one.arn
+}
+
 output "service_one_security_group_id" {
   description = "The ID of the security group for service one"
   value       = aws_security_group.service_one.id
+}
+
+output "service_tow_security_group_arn" {
+  description = "The ARN of the security group for service two"
+  value       = aws_security_group.service_two.arn
 }
 
 output "service_two_security_group_id" {

--- a/examples/rules-only/versions.tf
+++ b/examples/rules-only/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/_templates/outputs.tf
+++ b/modules/_templates/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/_templates/versions.tf
+++ b/modules/_templates/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/activemq/README.md
+++ b/modules/activemq/README.md
@@ -19,7 +19,7 @@ All automatic values **activemq module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/activemq/outputs.tf
+++ b/modules/activemq/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/activemq/versions.tf
+++ b/modules/activemq/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/alertmanager/README.md
+++ b/modules/alertmanager/README.md
@@ -19,7 +19,7 @@ All automatic values **alertmanager module** is using are available [here](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/alertmanager/outputs.tf
+++ b/modules/alertmanager/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/alertmanager/versions.tf
+++ b/modules/alertmanager/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/carbon-relay-ng/README.md
+++ b/modules/carbon-relay-ng/README.md
@@ -19,7 +19,7 @@ All automatic values **carbon-relay-ng module** is using are available [here](ht
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/carbon-relay-ng/outputs.tf
+++ b/modules/carbon-relay-ng/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/carbon-relay-ng/versions.tf
+++ b/modules/carbon-relay-ng/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/cassandra/README.md
+++ b/modules/cassandra/README.md
@@ -19,7 +19,7 @@ All automatic values **cassandra module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/cassandra/outputs.tf
+++ b/modules/cassandra/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/cassandra/versions.tf
+++ b/modules/cassandra/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/consul/README.md
+++ b/modules/consul/README.md
@@ -19,7 +19,7 @@ All automatic values **consul module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/consul/outputs.tf
+++ b/modules/consul/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/consul/versions.tf
+++ b/modules/consul/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/docker-swarm/README.md
+++ b/modules/docker-swarm/README.md
@@ -19,7 +19,7 @@ All automatic values **docker-swarm module** is using are available [here](https
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/docker-swarm/outputs.tf
+++ b/modules/docker-swarm/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/docker-swarm/versions.tf
+++ b/modules/docker-swarm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/elasticsearch/README.md
+++ b/modules/elasticsearch/README.md
@@ -19,7 +19,7 @@ All automatic values **elasticsearch module** is using are available [here](http
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/elasticsearch/outputs.tf
+++ b/modules/elasticsearch/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/elasticsearch/versions.tf
+++ b/modules/elasticsearch/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/etcd/README.md
+++ b/modules/etcd/README.md
@@ -19,7 +19,7 @@ All automatic values **etcd module** is using are available [here](https://githu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/etcd/outputs.tf
+++ b/modules/etcd/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/etcd/versions.tf
+++ b/modules/etcd/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/grafana/README.md
+++ b/modules/grafana/README.md
@@ -19,7 +19,7 @@ All automatic values **grafana module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/grafana/outputs.tf
+++ b/modules/grafana/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/grafana/versions.tf
+++ b/modules/grafana/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/graphite-statsd/README.md
+++ b/modules/graphite-statsd/README.md
@@ -19,7 +19,7 @@ All automatic values **graphite-statsd module** is using are available [here](ht
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/graphite-statsd/outputs.tf
+++ b/modules/graphite-statsd/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/graphite-statsd/versions.tf
+++ b/modules/graphite-statsd/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/http-80/README.md
+++ b/modules/http-80/README.md
@@ -19,7 +19,7 @@ All automatic values **http-80 module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/http-80/outputs.tf
+++ b/modules/http-80/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/http-80/versions.tf
+++ b/modules/http-80/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/http-8080/README.md
+++ b/modules/http-8080/README.md
@@ -19,7 +19,7 @@ All automatic values **http-8080 module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/http-8080/outputs.tf
+++ b/modules/http-8080/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/http-8080/versions.tf
+++ b/modules/http-8080/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/https-443/README.md
+++ b/modules/https-443/README.md
@@ -19,7 +19,7 @@ All automatic values **https-443 module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/https-443/outputs.tf
+++ b/modules/https-443/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/https-443/versions.tf
+++ b/modules/https-443/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/https-8443/README.md
+++ b/modules/https-8443/README.md
@@ -19,7 +19,7 @@ All automatic values **https-8443 module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/https-8443/outputs.tf
+++ b/modules/https-8443/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/https-8443/versions.tf
+++ b/modules/https-8443/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/ipsec-4500/README.md
+++ b/modules/ipsec-4500/README.md
@@ -19,7 +19,7 @@ All automatic values **ipsec-4500 module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/ipsec-4500/outputs.tf
+++ b/modules/ipsec-4500/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/ipsec-4500/versions.tf
+++ b/modules/ipsec-4500/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/ipsec-500/README.md
+++ b/modules/ipsec-500/README.md
@@ -19,7 +19,7 @@ All automatic values **ipsec-500 module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/ipsec-500/outputs.tf
+++ b/modules/ipsec-500/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/ipsec-500/versions.tf
+++ b/modules/ipsec-500/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -19,7 +19,7 @@ All automatic values **kafka module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/kafka/outputs.tf
+++ b/modules/kafka/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/kafka/versions.tf
+++ b/modules/kafka/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/kibana/README.md
+++ b/modules/kibana/README.md
@@ -19,7 +19,7 @@ All automatic values **kibana module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/kibana/outputs.tf
+++ b/modules/kibana/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/kibana/versions.tf
+++ b/modules/kibana/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/kubernetes-api/README.md
+++ b/modules/kubernetes-api/README.md
@@ -19,7 +19,7 @@ All automatic values **kubernetes-api module** is using are available [here](htt
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/kubernetes-api/outputs.tf
+++ b/modules/kubernetes-api/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/kubernetes-api/versions.tf
+++ b/modules/kubernetes-api/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/ldap/README.md
+++ b/modules/ldap/README.md
@@ -19,7 +19,7 @@ All automatic values **ldap module** is using are available [here](https://githu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/ldap/outputs.tf
+++ b/modules/ldap/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/ldap/versions.tf
+++ b/modules/ldap/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/ldaps/README.md
+++ b/modules/ldaps/README.md
@@ -19,7 +19,7 @@ All automatic values **ldaps module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/ldaps/outputs.tf
+++ b/modules/ldaps/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/ldaps/versions.tf
+++ b/modules/ldaps/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/logstash/README.md
+++ b/modules/logstash/README.md
@@ -19,7 +19,7 @@ All automatic values **logstash module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/logstash/outputs.tf
+++ b/modules/logstash/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/logstash/versions.tf
+++ b/modules/logstash/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/memcached/README.md
+++ b/modules/memcached/README.md
@@ -19,7 +19,7 @@ All automatic values **memcached module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/memcached/outputs.tf
+++ b/modules/memcached/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/memcached/versions.tf
+++ b/modules/memcached/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/minio/README.md
+++ b/modules/minio/README.md
@@ -19,7 +19,7 @@ All automatic values **minio module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/minio/outputs.tf
+++ b/modules/minio/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/minio/versions.tf
+++ b/modules/minio/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/mongodb/README.md
+++ b/modules/mongodb/README.md
@@ -19,7 +19,7 @@ All automatic values **mongodb module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/mongodb/outputs.tf
+++ b/modules/mongodb/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/mongodb/versions.tf
+++ b/modules/mongodb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/mssql/README.md
+++ b/modules/mssql/README.md
@@ -19,7 +19,7 @@ All automatic values **mssql module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/mssql/outputs.tf
+++ b/modules/mssql/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/mssql/versions.tf
+++ b/modules/mssql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/mysql/README.md
+++ b/modules/mysql/README.md
@@ -19,7 +19,7 @@ All automatic values **mysql module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/mysql/outputs.tf
+++ b/modules/mysql/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/mysql/versions.tf
+++ b/modules/mysql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/nfs/README.md
+++ b/modules/nfs/README.md
@@ -19,7 +19,7 @@ All automatic values **nfs module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/nfs/outputs.tf
+++ b/modules/nfs/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/nfs/versions.tf
+++ b/modules/nfs/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/nomad/README.md
+++ b/modules/nomad/README.md
@@ -19,7 +19,7 @@ All automatic values **nomad module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/nomad/outputs.tf
+++ b/modules/nomad/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/nomad/versions.tf
+++ b/modules/nomad/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/ntp/README.md
+++ b/modules/ntp/README.md
@@ -19,7 +19,7 @@ All automatic values **ntp module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/ntp/outputs.tf
+++ b/modules/ntp/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/ntp/versions.tf
+++ b/modules/ntp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/openvpn/README.md
+++ b/modules/openvpn/README.md
@@ -19,7 +19,7 @@ All automatic values **openvpn module** is using are available [here](https://gi
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/openvpn/outputs.tf
+++ b/modules/openvpn/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/openvpn/versions.tf
+++ b/modules/openvpn/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/oracle-db/README.md
+++ b/modules/oracle-db/README.md
@@ -19,7 +19,7 @@ All automatic values **oracle-db module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/oracle-db/outputs.tf
+++ b/modules/oracle-db/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/oracle-db/versions.tf
+++ b/modules/oracle-db/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/postgresql/README.md
+++ b/modules/postgresql/README.md
@@ -19,7 +19,7 @@ All automatic values **postgresql module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/postgresql/versions.tf
+++ b/modules/postgresql/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/prometheus/README.md
+++ b/modules/prometheus/README.md
@@ -19,7 +19,7 @@ All automatic values **prometheus module** is using are available [here](https:/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/prometheus/outputs.tf
+++ b/modules/prometheus/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/prometheus/versions.tf
+++ b/modules/prometheus/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/puppet/README.md
+++ b/modules/puppet/README.md
@@ -19,7 +19,7 @@ All automatic values **puppet module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/puppet/outputs.tf
+++ b/modules/puppet/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/puppet/versions.tf
+++ b/modules/puppet/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/rabbitmq/README.md
+++ b/modules/rabbitmq/README.md
@@ -19,7 +19,7 @@ All automatic values **rabbitmq module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/rabbitmq/outputs.tf
+++ b/modules/rabbitmq/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/rabbitmq/versions.tf
+++ b/modules/rabbitmq/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/rdp/README.md
+++ b/modules/rdp/README.md
@@ -19,7 +19,7 @@ All automatic values **rdp module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/rdp/outputs.tf
+++ b/modules/rdp/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/rdp/versions.tf
+++ b/modules/rdp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/redis/README.md
+++ b/modules/redis/README.md
@@ -19,7 +19,7 @@ All automatic values **redis module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/redis/versions.tf
+++ b/modules/redis/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/redshift/README.md
+++ b/modules/redshift/README.md
@@ -19,7 +19,7 @@ All automatic values **redshift module** is using are available [here](https://g
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/redshift/outputs.tf
+++ b/modules/redshift/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/redshift/versions.tf
+++ b/modules/redshift/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/smtp-submission/README.md
+++ b/modules/smtp-submission/README.md
@@ -19,7 +19,7 @@ All automatic values **smtp-submission module** is using are available [here](ht
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/smtp-submission/outputs.tf
+++ b/modules/smtp-submission/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/smtp-submission/versions.tf
+++ b/modules/smtp-submission/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/smtp/README.md
+++ b/modules/smtp/README.md
@@ -19,7 +19,7 @@ All automatic values **smtp module** is using are available [here](https://githu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/smtp/outputs.tf
+++ b/modules/smtp/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/smtp/versions.tf
+++ b/modules/smtp/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/smtps/README.md
+++ b/modules/smtps/README.md
@@ -19,7 +19,7 @@ All automatic values **smtps module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/smtps/outputs.tf
+++ b/modules/smtps/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/smtps/versions.tf
+++ b/modules/smtps/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/solr/README.md
+++ b/modules/solr/README.md
@@ -19,7 +19,7 @@ All automatic values **solr module** is using are available [here](https://githu
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/solr/outputs.tf
+++ b/modules/solr/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/solr/versions.tf
+++ b/modules/solr/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/splunk/README.md
+++ b/modules/splunk/README.md
@@ -19,7 +19,7 @@ All automatic values **splunk module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/splunk/outputs.tf
+++ b/modules/splunk/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/splunk/versions.tf
+++ b/modules/splunk/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/squid/README.md
+++ b/modules/squid/README.md
@@ -19,7 +19,7 @@ All automatic values **squid module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/squid/outputs.tf
+++ b/modules/squid/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/squid/versions.tf
+++ b/modules/squid/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/ssh/README.md
+++ b/modules/ssh/README.md
@@ -19,7 +19,7 @@ All automatic values **ssh module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/ssh/outputs.tf
+++ b/modules/ssh/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/ssh/versions.tf
+++ b/modules/ssh/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/storm/README.md
+++ b/modules/storm/README.md
@@ -19,7 +19,7 @@ All automatic values **storm module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/storm/outputs.tf
+++ b/modules/storm/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/storm/versions.tf
+++ b/modules/storm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/web/README.md
+++ b/modules/web/README.md
@@ -19,7 +19,7 @@ All automatic values **web module** is using are available [here](https://github
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/web/outputs.tf
+++ b/modules/web/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/web/versions.tf
+++ b/modules/web/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/winrm/README.md
+++ b/modules/winrm/README.md
@@ -19,7 +19,7 @@ All automatic values **winrm module** is using are available [here](https://gith
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/winrm/outputs.tf
+++ b/modules/winrm/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/winrm/versions.tf
+++ b/modules/winrm/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/zipkin/README.md
+++ b/modules/zipkin/README.md
@@ -19,7 +19,7 @@ All automatic values **zipkin module** is using are available [here](https://git
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/zipkin/outputs.tf
+++ b/modules/zipkin/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/zipkin/versions.tf
+++ b/modules/zipkin/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/modules/zookeeper/README.md
+++ b/modules/zookeeper/README.md
@@ -19,7 +19,7 @@ All automatic values **zookeeper module** is using are available [here](https://
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
 
 ## Providers
 
@@ -111,6 +111,7 @@ No resources.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
 | <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
 | <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |

--- a/modules/zookeeper/outputs.tf
+++ b/modules/zookeeper/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = module.sg.security_group_id

--- a/modules/zookeeper/versions.tf
+++ b/modules/zookeeper/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = try(aws_security_group.this[0].arn, aws_security_group.this_name_prefix[0].arn, "")
+}
+
 output "security_group_id" {
   description = "The ID of the security group"
   value       = try(aws_security_group.this[0].id, aws_security_group.this_name_prefix[0].id, "")

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.29"
     }
   }
 }


### PR DESCRIPTION
## Description
* The ARN of the security group
* Update required version of AWS provider to >= 3.29

## Motivation and Context
Fixes #247.

## Breaking Changes
I think this requires a new release, because the new output is only available since version 3.29.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

**complete:**
```
Apply complete! Resources: 44 added, 0 changed, 0 destroyed.

Outputs:

security_group_arn = "arn:aws:ec2:eu-west-1:590606209411:security-group/sg-0444c3f9155890a0a"
security_group_description = "Security group with all available arguments set (this is just an example)"
security_group_id = "sg-0444c3f9155890a0a"
security_group_name = "complete-sg-20220808074808410500000002"
security_group_owner_id = "590606209411"
security_group_vpc_id = "vpc-09780c5d1816dfb9f"
```
**computed:**
```
Apply complete! Resources: 10 added, 0 changed, 0 destroyed.

Outputs:

security_group_arn = "arn:aws:ec2:eu-west-1:590606209411:security-group/sg-0fc266db9e3fbc80b"
security_group_description = "Security group with MySQL/Aurora port open for HTTP security group created above (computed)"
security_group_id = "sg-0fc266db9e3fbc80b"
security_group_name = "computed-mysql-sg-20220808080319588200000001"
security_group_owner_id = "590606209411"
security_group_vpc_id = "vpc-09780c5d1816dfb9f"
```
**disabled:**
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

security_group_arn = ""
security_group_id = ""
```
**dynamic:**
```
Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

security_group_arn = "arn:aws:ec2:eu-west-1:590606209411:security-group/sg-08786fd7b2f028e15"
security_group_description = "Security group with HTTP port open for everyone, and HTTPS open just for the default security group"
security_group_id = "sg-08786fd7b2f028e15"
security_group_name = "dynamic-http-sg-20220808080943115200000001"
security_group_owner_id = "590606209411"
security_group_vpc_id = "vpc-09780c5d1816dfb9f"
```
**http:**
```
Apply complete! Resources: 24 added, 0 changed, 0 destroyed.

Outputs:

security_group_arn = "arn:aws:ec2:eu-west-1:590606209411:security-group/sg-0fd704743a5fc8375"
security_group_description = "Security group with HTTP ports open for everybody (IPv4 CIDR), egress ports are all world open"
security_group_id = "sg-0fd704743a5fc8375"
security_group_name = "http-sg-20220808081359706900000004"
security_group_owner_id = "590606209411"
security_group_vpc_id = "vpc-09780c5d1816dfb9f"
```
**rules-only:**
```
Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

service_one_security_group_arn = "arn:aws:ec2:eu-west-1:590606209411:security-group/sg-02286e4a4e0e8b756"
service_one_security_group_id = "sg-02286e4a4e0e8b756"
service_tow_security_group_arn = "arn:aws:ec2:eu-west-1:590606209411:security-group/sg-0aafe86440d138bd7"
service_two_security_group_id = "sg-0aafe86440d138bd7"
```
- [x] I have executed `pre-commit run -a` on my pull request
```
➜ pre-commit run -a
Terraform fmt............................................................Passed
Terraform validate.......................................................Failed
- hook id: terraform_validate
- exit code: 1

Validation failed: modules/_templates
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 16, in module "sg":
│   16:   ingress_rules = sort(compact(distinct(concat(var.auto_ingress_rules, var.ingress_rules, [""]))))
│
│ An input variable with the name "auto_ingress_rules" has not been declared.
│ This variable can be declared with a variable "auto_ingress_rules" {}
│ block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 19, in module "sg":
│   19:   ingress_with_self = concat(var.auto_ingress_with_self, var.ingress_with_self)
│
│ An input variable with the name "auto_ingress_with_self" has not been
│ declared. This variable can be declared with a variable
│ "auto_ingress_with_self" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 41, in module "sg":
│   41:   computed_ingress_rules = sort(compact(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules, [""]))))
│
│ An input variable with the name "auto_computed_ingress_rules" has not been
│ declared. This variable can be declared with a variable
│ "auto_computed_ingress_rules" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 44, in module "sg":
│   44:   computed_ingress_with_self = concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)
│
│ An input variable with the name "auto_computed_ingress_with_self" has not
│ been declared. This variable can be declared with a variable
│ "auto_computed_ingress_with_self" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 58, in module "sg":
│   58:   number_of_computed_ingress_rules                         = var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules
│
│ An input variable with the name "auto_number_of_computed_ingress_rules" has
│ not been declared. This variable can be declared with a variable
│ "auto_number_of_computed_ingress_rules" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 59, in module "sg":
│   59:   number_of_computed_ingress_with_self                     = var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self
│
│ An input variable with the name "auto_number_of_computed_ingress_with_self"
│ has not been declared. This variable can be declared with a variable
│ "auto_number_of_computed_ingress_with_self" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 68, in module "sg":
│   68:   egress_rules = sort(compact(distinct(concat(var.auto_egress_rules, var.egress_rules, [""]))))
│
│ An input variable with the name "auto_egress_rules" has not been declared.
│ This variable can be declared with a variable "auto_egress_rules" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 71, in module "sg":
│   71:   egress_with_self = concat(var.auto_egress_with_self, var.egress_with_self)
│
│ An input variable with the name "auto_egress_with_self" has not been
│ declared. This variable can be declared with a variable
│ "auto_egress_with_self" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 93, in module "sg":
│   93:   computed_egress_rules = sort(compact(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules, [""]))))
│
│ An input variable with the name "auto_computed_egress_rules" has not been
│ declared. This variable can be declared with a variable
│ "auto_computed_egress_rules" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 96, in module "sg":
│   96:   computed_egress_with_self = concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)
│
│ An input variable with the name "auto_computed_egress_with_self" has not
│ been declared. This variable can be declared with a variable
│ "auto_computed_egress_with_self" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 110, in module "sg":
│  110:   number_of_computed_egress_rules                         = var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules
│
│ An input variable with the name "auto_number_of_computed_egress_rules" has
│ not been declared. This variable can be declared with a variable
│ "auto_number_of_computed_egress_rules" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on main.tf line 111, in module "sg":
│  111:   number_of_computed_egress_with_self                     = var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self
│
│ An input variable with the name "auto_number_of_computed_egress_with_self"
│ has not been declared. This variable can be declared with a variable
│ "auto_number_of_computed_egress_with_self" {} block.
╵

Terraform docs...........................................................Passed
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
```
