### PR TITLE
Added more kafka and zookeeper rules

### DIFF
--- a/modules/kafka/auto_values.tf
+++ b/modules/kafka/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = list(string)
-  default     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
+  default     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-broker-iam-tcp", , "kafka-broker-sasl-scram-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/modules/kafka/auto_values.tf
+++ b/modules/kafka/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = list(string)
-  default     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-broker-iam-tcp", , "kafka-broker-sasl-scram-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
+  default     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-broker-sasl-scram-tcp", "kafka-broker-iam-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/modules/kafka/auto_values.tf
+++ b/modules/kafka/auto_values.tf
@@ -6,7 +6,7 @@
 variable "auto_ingress_rules" {
   description = "List of ingress rules to add automatically"
   type        = list(string)
-  default     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-broker-sasl-scram-tcp", "kafka-broker-iam-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
+  default     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-broker-sasl-scram-tcp", "kafka-broker-iam-tcp", "kafka-broker-public-iam-tcp", "zookeeper-nodes-tcp", "zookeeper-nodes-tls-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
 }
 
 variable "auto_ingress_with_self" {

--- a/rules.tf
+++ b/rules.tf
@@ -76,8 +76,11 @@ variable "rules" {
     # Kafka
     kafka-broker-tcp            = [9092, 9092, "tcp", "Kafka broker 0.8.2+"]
     kafka-broker-tls-tcp        = [9094, 9094, "tcp", "Kafka TLS enabled broker 0.8.2+"]
+    kafka-broker-public-tls-tcp = [9198, 9198, "tcp", "Kafka public TLS enabled broker 0.8.2+"]
     kafka-broker-sasl-scram-tcp = [9096, 9096, "tcp", "Kafka SASL-SCRAM/TLS enabled broker 0.8.2+"]
     kafka-broker-iam-tcp        = [9098, 9098, "tcp", "Kafka IAM/TLS enabled broker 0.8.2+"]
+    zookeeper-node-tcp          = [2181, 2181, "tcp", "Zookeeper nodes 0.8.2+"]
+    zookeeper-node-tls-tcp      = [2182, 2182, "tcp", "Zookeeper nodes 0.8.2+"]
     kafka-jmx-exporter-tcp      = [11001, 11001, "tcp", "Kafka JMX Exporter"]
     kafka-node-exporter-tcp     = [11002, 11002, "tcp", "Kafka Node Exporter"]
     # Kibana

--- a/rules.tf
+++ b/rules.tf
@@ -76,8 +76,8 @@ variable "rules" {
     # Kafka
     kafka-broker-tcp            = [9092, 9092, "tcp", "Kafka broker 0.8.2+"]
     kafka-broker-tls-tcp        = [9094, 9094, "tcp", "Kafka TLS enabled broker 0.8.2+"]
+    kafka-broker-sasl-scram-tcp = [9096, 9096, "tcp", "Kafka SASL-SCRAM/TLS enabled broker 0.8.2+"]
     kafka-broker-iam-tcp        = [9098, 9098, "tcp", "Kafka IAM/TLS enabled broker 0.8.2+"]
-    kafka-broker-sasl-scram-tcp = [9094, 9096, "tcp", "Kafka SASL-SCRAM/TLS enabled broker 0.8.2+"]
     kafka-jmx-exporter-tcp      = [11001, 11001, "tcp", "Kafka JMX Exporter"]
     kafka-node-exporter-tcp     = [11002, 11002, "tcp", "Kafka Node Exporter"]
     # Kibana

--- a/rules.tf
+++ b/rules.tf
@@ -74,10 +74,12 @@ variable "rules" {
     ipsec-500-udp  = [500, 500, "udp", "IPSEC ISAKMP"]
     ipsec-4500-udp = [4500, 4500, "udp", "IPSEC NAT-T"]
     # Kafka
-    kafka-broker-tcp        = [9092, 9092, "tcp", "Kafka broker 0.8.2+"]
-    kafka-broker-tls-tcp    = [9094, 9094, "tcp", "Kafka TLS enabled broker 0.8.2+"]
-    kafka-jmx-exporter-tcp  = [11001, 11001, "tcp", "Kafka JMX Exporter"]
-    kafka-node-exporter-tcp = [11002, 11002, "tcp", "Kafka Node Exporter"]
+    kafka-broker-tcp            = [9092, 9092, "tcp", "Kafka broker 0.8.2+"]
+    kafka-broker-tls-tcp        = [9094, 9094, "tcp", "Kafka TLS enabled broker 0.8.2+"]
+    kafka-broker-iam-tcp        = [9098, 9098, "tcp", "Kafka IAM/TLS enabled broker 0.8.2+"]
+    kafka-broker-sasl-scram-tcp = [9094, 9096, "tcp", "Kafka SASL-SCRAM/TLS enabled broker 0.8.2+"]
+    kafka-jmx-exporter-tcp      = [11001, 11001, "tcp", "Kafka JMX Exporter"]
+    kafka-node-exporter-tcp     = [11002, 11002, "tcp", "Kafka Node Exporter"]
     # Kibana
     kibana-tcp = [5601, 5601, "tcp", "Kibana Web Interface"]
     # Kubernetes
@@ -276,7 +278,7 @@ variable "auto_groups" {
       egress_rules      = ["all-all"]
     }
     kafka = {
-      ingress_rules     = ["kafka-broker-tcp", "kafka-broker-tls-tcp", "kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
+      ingress_rules     = ["kafka-broker-tcp", "kafka-broker-tls-tcp",  "kafka-broker-sasl-scram-tcp",  "kafka-broker-iam-tcp","kafka-jmx-exporter-tcp", "kafka-node-exporter-tcp"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }

--- a/rules.tf
+++ b/rules.tf
@@ -76,11 +76,11 @@ variable "rules" {
     # Kafka
     kafka-broker-tcp            = [9092, 9092, "tcp", "Kafka broker 0.8.2+"]
     kafka-broker-tls-tcp        = [9094, 9094, "tcp", "Kafka TLS enabled broker 0.8.2+"]
-    kafka-broker-public-tls-tcp = [9198, 9198, "tcp", "Kafka public TLS enabled broker 0.8.2+"]
     kafka-broker-sasl-scram-tcp = [9096, 9096, "tcp", "Kafka SASL-SCRAM/TLS enabled broker 0.8.2+"]
     kafka-broker-iam-tcp        = [9098, 9098, "tcp", "Kafka IAM/TLS enabled broker 0.8.2+"]
-    zookeeper-node-tcp          = [2181, 2181, "tcp", "Zookeeper nodes 0.8.2+"]
-    zookeeper-node-tls-tcp      = [2182, 2182, "tcp", "Zookeeper nodes 0.8.2+"]
+    kafka-broker-public-iam-tcp = [9198, 9198, "tcp", "Kafka public IAM/TLS enabled broker 0.8.2+"]
+    zookeeper-nodes-tcp         = [2181, 2181, "tcp", "Zookeeper nodes 0.8.2+"]
+    zookeeper-nodes-tls-tcp     = [2182, 2182, "tcp", "Zookeeper nodes 0.8.2+"]
     kafka-jmx-exporter-tcp      = [11001, 11001, "tcp", "Kafka JMX Exporter"]
     kafka-node-exporter-tcp     = [11002, 11002, "tcp", "Kafka Node Exporter"]
     # Kibana


### PR DESCRIPTION
## Description

Added the remaining AWS MSK rule. See AWS [docs](https://docs.aws.amazon.com/msk/latest/developerguide/port-info.html) for complete list of MSK ports.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
support for complete set of AWS MSK ports

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
none

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
