### PR TITLE
feat: Added Zabbix rules

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -52,6 +52,7 @@ List of Security Groups implemented as Terraform modules
 * [wazuh](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/wazuh)
 * [web](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/web)
 * [winrm](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/winrm)
+* [zabbix](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/zabbix)
 * [zipkin](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/zipkin)
 * [zookeeper](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/zookeeper)
 * [_templates](https://github.com/terraform-aws-modules/terraform-aws-security-group/tree/master/modules/_templates) - Source templates for all other modules. Change carefully, test thoughtfully!

--- a/modules/zabbix/README.md
+++ b/modules/zabbix/README.md
@@ -1,0 +1,120 @@
+# zabbix - AWS EC2-VPC Security Group Terraform module
+
+## Usage
+
+```hcl
+module "zabbix_security_group" {
+  source  = "terraform-aws-modules/security-group/aws//modules/zabbix"
+  version = "~> 4.0"
+
+  # omitted...
+}
+```
+
+All automatic values **zabbix module** is using are available [here](https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/master/modules/zabbix/auto_values.tf).
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.29 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_sg"></a> [sg](#module\_sg) | ../../ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_auto_computed_egress_rules"></a> [auto\_computed\_egress\_rules](#input\_auto\_computed\_egress\_rules) | List of computed egress rules to add automatically | `list(string)` | `[]` | no |
+| <a name="input_auto_computed_egress_with_self"></a> [auto\_computed\_egress\_with\_self](#input\_auto\_computed\_egress\_with\_self) | List of maps defining computed egress rules with self to add automatically | `list(map(string))` | `[]` | no |
+| <a name="input_auto_computed_ingress_rules"></a> [auto\_computed\_ingress\_rules](#input\_auto\_computed\_ingress\_rules) | List of ingress rules to add automatically | `list(string)` | `[]` | no |
+| <a name="input_auto_computed_ingress_with_self"></a> [auto\_computed\_ingress\_with\_self](#input\_auto\_computed\_ingress\_with\_self) | List of maps defining computed ingress rules with self to add automatically | `list(map(string))` | `[]` | no |
+| <a name="input_auto_egress_rules"></a> [auto\_egress\_rules](#input\_auto\_egress\_rules) | List of egress rules to add automatically | `list(string)` | <pre>[<br>  "all-all"<br>]</pre> | no |
+| <a name="input_auto_egress_with_self"></a> [auto\_egress\_with\_self](#input\_auto\_egress\_with\_self) | List of maps defining egress rules with self to add automatically | `list(map(string))` | `[]` | no |
+| <a name="input_auto_ingress_rules"></a> [auto\_ingress\_rules](#input\_auto\_ingress\_rules) | List of ingress rules to add automatically | `list(string)` | <pre>[<br>  "zabbix-server",<br>  "zabbix-proxy",<br>  "zabbix-agent"<br>]</pre> | no |
+| <a name="input_auto_ingress_with_self"></a> [auto\_ingress\_with\_self](#input\_auto\_ingress\_with\_self) | List of maps defining ingress rules with self to add automatically | `list(map(string))` | <pre>[<br>  {<br>    "rule": "all-all"<br>  }<br>]</pre> | no |
+| <a name="input_auto_number_of_computed_egress_rules"></a> [auto\_number\_of\_computed\_egress\_rules](#input\_auto\_number\_of\_computed\_egress\_rules) | Number of computed egress rules to create by name | `number` | `0` | no |
+| <a name="input_auto_number_of_computed_egress_with_self"></a> [auto\_number\_of\_computed\_egress\_with\_self](#input\_auto\_number\_of\_computed\_egress\_with\_self) | Number of computed egress rules to create where 'self' is defined | `number` | `0` | no |
+| <a name="input_auto_number_of_computed_ingress_rules"></a> [auto\_number\_of\_computed\_ingress\_rules](#input\_auto\_number\_of\_computed\_ingress\_rules) | Number of computed ingress rules to create by name | `number` | `0` | no |
+| <a name="input_auto_number_of_computed_ingress_with_self"></a> [auto\_number\_of\_computed\_ingress\_with\_self](#input\_auto\_number\_of\_computed\_ingress\_with\_self) | Number of computed ingress rules to create where 'self' is defined | `number` | `0` | no |
+| <a name="input_computed_egress_cidr_blocks"></a> [computed\_egress\_cidr\_blocks](#input\_computed\_egress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all computed egress rules | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_computed_egress_ipv6_cidr_blocks"></a> [computed\_egress\_ipv6\_cidr\_blocks](#input\_computed\_egress\_ipv6\_cidr\_blocks) | List of IPv6 CIDR ranges to use on all computed egress rules | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
+| <a name="input_computed_egress_prefix_list_ids"></a> [computed\_egress\_prefix\_list\_ids](#input\_computed\_egress\_prefix\_list\_ids) | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | `list(string)` | `[]` | no |
+| <a name="input_computed_egress_rules"></a> [computed\_egress\_rules](#input\_computed\_egress\_rules) | List of computed egress rules to create by name | `list(string)` | `[]` | no |
+| <a name="input_computed_egress_with_cidr_blocks"></a> [computed\_egress\_with\_cidr\_blocks](#input\_computed\_egress\_with\_cidr\_blocks) | List of computed egress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_egress_with_ipv6_cidr_blocks"></a> [computed\_egress\_with\_ipv6\_cidr\_blocks](#input\_computed\_egress\_with\_ipv6\_cidr\_blocks) | List of computed egress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_egress_with_self"></a> [computed\_egress\_with\_self](#input\_computed\_egress\_with\_self) | List of computed egress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
+| <a name="input_computed_egress_with_source_security_group_id"></a> [computed\_egress\_with\_source\_security\_group\_id](#input\_computed\_egress\_with\_source\_security\_group\_id) | List of computed egress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_ingress_cidr_blocks"></a> [computed\_ingress\_cidr\_blocks](#input\_computed\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all computed ingress rules | `list(string)` | `[]` | no |
+| <a name="input_computed_ingress_ipv6_cidr_blocks"></a> [computed\_ingress\_ipv6\_cidr\_blocks](#input\_computed\_ingress\_ipv6\_cidr\_blocks) | List of IPv6 CIDR ranges to use on all computed ingress rules | `list(string)` | `[]` | no |
+| <a name="input_computed_ingress_prefix_list_ids"></a> [computed\_ingress\_prefix\_list\_ids](#input\_computed\_ingress\_prefix\_list\_ids) | List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | `list(string)` | `[]` | no |
+| <a name="input_computed_ingress_rules"></a> [computed\_ingress\_rules](#input\_computed\_ingress\_rules) | List of computed ingress rules to create by name | `list(string)` | `[]` | no |
+| <a name="input_computed_ingress_with_cidr_blocks"></a> [computed\_ingress\_with\_cidr\_blocks](#input\_computed\_ingress\_with\_cidr\_blocks) | List of computed ingress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_ingress_with_ipv6_cidr_blocks"></a> [computed\_ingress\_with\_ipv6\_cidr\_blocks](#input\_computed\_ingress\_with\_ipv6\_cidr\_blocks) | List of computed ingress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_computed_ingress_with_self"></a> [computed\_ingress\_with\_self](#input\_computed\_ingress\_with\_self) | List of computed ingress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
+| <a name="input_computed_ingress_with_source_security_group_id"></a> [computed\_ingress\_with\_source\_security\_group\_id](#input\_computed\_ingress\_with\_source\_security\_group\_id) | List of computed ingress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
+| <a name="input_create"></a> [create](#input\_create) | Whether to create security group and all rules | `bool` | `true` | no |
+| <a name="input_description"></a> [description](#input\_description) | Description of security group | `string` | `"Security Group managed by Terraform"` | no |
+| <a name="input_egress_cidr_blocks"></a> [egress\_cidr\_blocks](#input\_egress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all egress rules | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_egress_ipv6_cidr_blocks"></a> [egress\_ipv6\_cidr\_blocks](#input\_egress\_ipv6\_cidr\_blocks) | List of IPv6 CIDR ranges to use on all egress rules | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
+| <a name="input_egress_prefix_list_ids"></a> [egress\_prefix\_list\_ids](#input\_egress\_prefix\_list\_ids) | List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules | `list(string)` | `[]` | no |
+| <a name="input_egress_rules"></a> [egress\_rules](#input\_egress\_rules) | List of egress rules to create by name | `list(string)` | `[]` | no |
+| <a name="input_egress_with_cidr_blocks"></a> [egress\_with\_cidr\_blocks](#input\_egress\_with\_cidr\_blocks) | List of egress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_egress_with_ipv6_cidr_blocks"></a> [egress\_with\_ipv6\_cidr\_blocks](#input\_egress\_with\_ipv6\_cidr\_blocks) | List of egress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_egress_with_self"></a> [egress\_with\_self](#input\_egress\_with\_self) | List of egress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
+| <a name="input_egress_with_source_security_group_id"></a> [egress\_with\_source\_security\_group\_id](#input\_egress\_with\_source\_security\_group\_id) | List of egress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
+| <a name="input_ingress_cidr_blocks"></a> [ingress\_cidr\_blocks](#input\_ingress\_cidr\_blocks) | List of IPv4 CIDR ranges to use on all ingress rules | `list(string)` | `[]` | no |
+| <a name="input_ingress_ipv6_cidr_blocks"></a> [ingress\_ipv6\_cidr\_blocks](#input\_ingress\_ipv6\_cidr\_blocks) | List of IPv6 CIDR ranges to use on all ingress rules | `list(string)` | `[]` | no |
+| <a name="input_ingress_prefix_list_ids"></a> [ingress\_prefix\_list\_ids](#input\_ingress\_prefix\_list\_ids) | List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules | `list(string)` | `[]` | no |
+| <a name="input_ingress_rules"></a> [ingress\_rules](#input\_ingress\_rules) | List of ingress rules to create by name | `list(string)` | `[]` | no |
+| <a name="input_ingress_with_cidr_blocks"></a> [ingress\_with\_cidr\_blocks](#input\_ingress\_with\_cidr\_blocks) | List of ingress rules to create where 'cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_ingress_with_ipv6_cidr_blocks"></a> [ingress\_with\_ipv6\_cidr\_blocks](#input\_ingress\_with\_ipv6\_cidr\_blocks) | List of ingress rules to create where 'ipv6\_cidr\_blocks' is used | `list(map(string))` | `[]` | no |
+| <a name="input_ingress_with_self"></a> [ingress\_with\_self](#input\_ingress\_with\_self) | List of ingress rules to create where 'self' is defined | `list(map(string))` | `[]` | no |
+| <a name="input_ingress_with_source_security_group_id"></a> [ingress\_with\_source\_security\_group\_id](#input\_ingress\_with\_source\_security\_group\_id) | List of ingress rules to create where 'source\_security\_group\_id' is used | `list(map(string))` | `[]` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of security group | `string` | n/a | yes |
+| <a name="input_number_of_computed_egress_cidr_blocks"></a> [number\_of\_computed\_egress\_cidr\_blocks](#input\_number\_of\_computed\_egress\_cidr\_blocks) | Number of IPv4 CIDR ranges to use on all computed egress rules | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_ipv6_cidr_blocks"></a> [number\_of\_computed\_egress\_ipv6\_cidr\_blocks](#input\_number\_of\_computed\_egress\_ipv6\_cidr\_blocks) | Number of IPv6 CIDR ranges to use on all computed egress rules | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_prefix_list_ids"></a> [number\_of\_computed\_egress\_prefix\_list\_ids](#input\_number\_of\_computed\_egress\_prefix\_list\_ids) | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_rules"></a> [number\_of\_computed\_egress\_rules](#input\_number\_of\_computed\_egress\_rules) | Number of computed egress rules to create by name | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_with_cidr_blocks"></a> [number\_of\_computed\_egress\_with\_cidr\_blocks](#input\_number\_of\_computed\_egress\_with\_cidr\_blocks) | Number of computed egress rules to create where 'cidr\_blocks' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_with_ipv6_cidr_blocks"></a> [number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks](#input\_number\_of\_computed\_egress\_with\_ipv6\_cidr\_blocks) | Number of computed egress rules to create where 'ipv6\_cidr\_blocks' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_with_self"></a> [number\_of\_computed\_egress\_with\_self](#input\_number\_of\_computed\_egress\_with\_self) | Number of computed egress rules to create where 'self' is defined | `number` | `0` | no |
+| <a name="input_number_of_computed_egress_with_source_security_group_id"></a> [number\_of\_computed\_egress\_with\_source\_security\_group\_id](#input\_number\_of\_computed\_egress\_with\_source\_security\_group\_id) | Number of computed egress rules to create where 'source\_security\_group\_id' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_cidr_blocks"></a> [number\_of\_computed\_ingress\_cidr\_blocks](#input\_number\_of\_computed\_ingress\_cidr\_blocks) | Number of IPv4 CIDR ranges to use on all computed ingress rules | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_ipv6_cidr_blocks"></a> [number\_of\_computed\_ingress\_ipv6\_cidr\_blocks](#input\_number\_of\_computed\_ingress\_ipv6\_cidr\_blocks) | Number of IPv6 CIDR ranges to use on all computed ingress rules | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_prefix_list_ids"></a> [number\_of\_computed\_ingress\_prefix\_list\_ids](#input\_number\_of\_computed\_ingress\_prefix\_list\_ids) | Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_rules"></a> [number\_of\_computed\_ingress\_rules](#input\_number\_of\_computed\_ingress\_rules) | Number of computed ingress rules to create by name | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_with_cidr_blocks"></a> [number\_of\_computed\_ingress\_with\_cidr\_blocks](#input\_number\_of\_computed\_ingress\_with\_cidr\_blocks) | Number of computed ingress rules to create where 'cidr\_blocks' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_with_ipv6_cidr_blocks"></a> [number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks](#input\_number\_of\_computed\_ingress\_with\_ipv6\_cidr\_blocks) | Number of computed ingress rules to create where 'ipv6\_cidr\_blocks' is used | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_with_self"></a> [number\_of\_computed\_ingress\_with\_self](#input\_number\_of\_computed\_ingress\_with\_self) | Number of computed ingress rules to create where 'self' is defined | `number` | `0` | no |
+| <a name="input_number_of_computed_ingress_with_source_security_group_id"></a> [number\_of\_computed\_ingress\_with\_source\_security\_group\_id](#input\_number\_of\_computed\_ingress\_with\_source\_security\_group\_id) | Number of computed ingress rules to create where 'source\_security\_group\_id' is used | `number` | `0` | no |
+| <a name="input_revoke_rules_on_delete"></a> [revoke\_rules\_on\_delete](#input\_revoke\_rules\_on\_delete) | Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. Enable for EMR. | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to security group | `map(string)` | `{}` | no |
+| <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Whether to use name\_prefix or fixed name. Should be true to able to update security group name after initial creation | `bool` | `true` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where to create security group | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | The ARN of the security group |
+| <a name="output_security_group_description"></a> [security\_group\_description](#output\_security\_group\_description) | The description of the security group |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
+| <a name="output_security_group_name"></a> [security\_group\_name](#output\_security\_group\_name) | The name of the security group |
+| <a name="output_security_group_owner_id"></a> [security\_group\_owner\_id](#output\_security\_group\_owner\_id) | The owner ID |
+| <a name="output_security_group_vpc_id"></a> [security\_group\_vpc\_id](#output\_security\_group\_vpc\_id) | The VPC ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/zabbix/auto_values.tf
+++ b/modules/zabbix/auto_values.tf
@@ -1,0 +1,78 @@
+# This file was generated from values defined in rules.tf using update_groups.sh.
+###################################
+# DO NOT CHANGE THIS FILE MANUALLY
+###################################
+
+variable "auto_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = list(string)
+  default     = ["zabbix-server", "zabbix-proxy", "zabbix-agent"]
+}
+
+variable "auto_ingress_with_self" {
+  description = "List of maps defining ingress rules with self to add automatically"
+  type        = list(map(string))
+  default     = [{ "rule" = "all-all" }]
+}
+
+variable "auto_egress_rules" {
+  description = "List of egress rules to add automatically"
+  type        = list(string)
+  default     = ["all-all"]
+}
+
+variable "auto_egress_with_self" {
+  description = "List of maps defining egress rules with self to add automatically"
+  type        = list(map(string))
+  default     = []
+}
+
+# Computed
+variable "auto_computed_ingress_rules" {
+  description = "List of ingress rules to add automatically"
+  type        = list(string)
+  default     = []
+}
+
+variable "auto_computed_ingress_with_self" {
+  description = "List of maps defining computed ingress rules with self to add automatically"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "auto_computed_egress_rules" {
+  description = "List of computed egress rules to add automatically"
+  type        = list(string)
+  default     = []
+}
+
+variable "auto_computed_egress_with_self" {
+  description = "List of maps defining computed egress rules with self to add automatically"
+  type        = list(map(string))
+  default     = []
+}
+
+# Number of computed rules
+variable "auto_number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  type        = number
+  default     = 0
+}
+
+variable "auto_number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  type        = number
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  type        = number
+  default     = 0
+}
+
+variable "auto_number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  type        = number
+  default     = 0
+}

--- a/modules/zabbix/main.tf
+++ b/modules/zabbix/main.tf
@@ -1,0 +1,115 @@
+module "sg" {
+  source = "../../"
+
+  create                 = var.create
+  name                   = var.name
+  use_name_prefix        = var.use_name_prefix
+  description            = var.description
+  vpc_id                 = var.vpc_id
+  revoke_rules_on_delete = var.revoke_rules_on_delete
+  tags                   = var.tags
+
+  ##########
+  # Ingress
+  ##########
+  # Rules by names - open for default CIDR
+  ingress_rules = sort(compact(distinct(concat(var.auto_ingress_rules, var.ingress_rules, [""]))))
+
+  # Open for self
+  ingress_with_self = concat(var.auto_ingress_with_self, var.ingress_with_self)
+
+  # Open to IPv4 cidr blocks
+  ingress_with_cidr_blocks = var.ingress_with_cidr_blocks
+
+  # Open to IPv6 cidr blocks
+  ingress_with_ipv6_cidr_blocks = var.ingress_with_ipv6_cidr_blocks
+
+  # Open for security group id
+  ingress_with_source_security_group_id = var.ingress_with_source_security_group_id
+
+  # Default ingress CIDR blocks
+  ingress_cidr_blocks      = var.ingress_cidr_blocks
+  ingress_ipv6_cidr_blocks = var.ingress_ipv6_cidr_blocks
+
+  # Default prefix list ids
+  ingress_prefix_list_ids = var.ingress_prefix_list_ids
+
+  ###################
+  # Computed Ingress
+  ###################
+  # Rules by names - open for default CIDR
+  computed_ingress_rules = sort(compact(distinct(concat(var.auto_computed_ingress_rules, var.computed_ingress_rules, [""]))))
+
+  # Open for self
+  computed_ingress_with_self = concat(var.auto_computed_ingress_with_self, var.computed_ingress_with_self)
+
+  # Open to IPv4 cidr blocks
+  computed_ingress_with_cidr_blocks = var.computed_ingress_with_cidr_blocks
+
+  # Open to IPv6 cidr blocks
+  computed_ingress_with_ipv6_cidr_blocks = var.computed_ingress_with_ipv6_cidr_blocks
+
+  # Open for security group id
+  computed_ingress_with_source_security_group_id = var.computed_ingress_with_source_security_group_id
+
+  #############################
+  # Number of computed ingress
+  #############################
+  number_of_computed_ingress_rules                         = var.auto_number_of_computed_ingress_rules + var.number_of_computed_ingress_rules
+  number_of_computed_ingress_with_self                     = var.auto_number_of_computed_ingress_with_self + var.number_of_computed_ingress_with_self
+  number_of_computed_ingress_with_cidr_blocks              = var.number_of_computed_ingress_with_cidr_blocks
+  number_of_computed_ingress_with_ipv6_cidr_blocks         = var.number_of_computed_ingress_with_ipv6_cidr_blocks
+  number_of_computed_ingress_with_source_security_group_id = var.number_of_computed_ingress_with_source_security_group_id
+
+  #########
+  # Egress
+  #########
+  # Rules by names - open for default CIDR
+  egress_rules = sort(compact(distinct(concat(var.auto_egress_rules, var.egress_rules, [""]))))
+
+  # Open for self
+  egress_with_self = concat(var.auto_egress_with_self, var.egress_with_self)
+
+  # Open to IPv4 cidr blocks
+  egress_with_cidr_blocks = var.egress_with_cidr_blocks
+
+  # Open to IPv6 cidr blocks
+  egress_with_ipv6_cidr_blocks = var.egress_with_ipv6_cidr_blocks
+
+  # Open for security group id
+  egress_with_source_security_group_id = var.egress_with_source_security_group_id
+
+  # Default egress CIDR blocks
+  egress_cidr_blocks      = var.egress_cidr_blocks
+  egress_ipv6_cidr_blocks = var.egress_ipv6_cidr_blocks
+
+  # Default prefix list ids
+  egress_prefix_list_ids = var.egress_prefix_list_ids
+
+  ##################
+  # Computed Egress
+  ##################
+  # Rules by names - open for default CIDR
+  computed_egress_rules = sort(compact(distinct(concat(var.auto_computed_egress_rules, var.computed_egress_rules, [""]))))
+
+  # Open for self
+  computed_egress_with_self = concat(var.auto_computed_egress_with_self, var.computed_egress_with_self)
+
+  # Open to IPv4 cidr blocks
+  computed_egress_with_cidr_blocks = var.computed_egress_with_cidr_blocks
+
+  # Open to IPv6 cidr blocks
+  computed_egress_with_ipv6_cidr_blocks = var.computed_egress_with_ipv6_cidr_blocks
+
+  # Open for security group id
+  computed_egress_with_source_security_group_id = var.computed_egress_with_source_security_group_id
+
+  #############################
+  # Number of computed egress
+  #############################
+  number_of_computed_egress_rules                         = var.auto_number_of_computed_egress_rules + var.number_of_computed_egress_rules
+  number_of_computed_egress_with_self                     = var.auto_number_of_computed_egress_with_self + var.number_of_computed_egress_with_self
+  number_of_computed_egress_with_cidr_blocks              = var.number_of_computed_egress_with_cidr_blocks
+  number_of_computed_egress_with_ipv6_cidr_blocks         = var.number_of_computed_egress_with_ipv6_cidr_blocks
+  number_of_computed_egress_with_source_security_group_id = var.number_of_computed_egress_with_source_security_group_id
+}

--- a/modules/zabbix/outputs.tf
+++ b/modules/zabbix/outputs.tf
@@ -1,0 +1,29 @@
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = module.sg.security_group_arn
+}
+
+output "security_group_id" {
+  description = "The ID of the security group"
+  value       = module.sg.security_group_id
+}
+
+output "security_group_vpc_id" {
+  description = "The VPC ID"
+  value       = module.sg.security_group_vpc_id
+}
+
+output "security_group_owner_id" {
+  description = "The owner ID"
+  value       = module.sg.security_group_owner_id
+}
+
+output "security_group_name" {
+  description = "The name of the security group"
+  value       = module.sg.security_group_name
+}
+
+output "security_group_description" {
+  description = "The description of the security group"
+  value       = module.sg.security_group_description
+}

--- a/modules/zabbix/variables.tf
+++ b/modules/zabbix/variables.tf
@@ -1,0 +1,348 @@
+#################
+# Security group
+#################
+variable "create" {
+  description = "Whether to create security group and all rules"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where to create security group"
+  type        = string
+}
+
+variable "name" {
+  description = "Name of security group"
+  type        = string
+}
+
+variable "use_name_prefix" {
+  description = "Whether to use name_prefix or fixed name. Should be true to able to update security group name after initial creation"
+  type        = bool
+  default     = true
+}
+
+variable "description" {
+  description = "Description of security group"
+  type        = string
+  default     = "Security Group managed by Terraform"
+}
+
+variable "revoke_rules_on_delete" {
+  description = "Instruct Terraform to revoke all of the Security Groups attached ingress and egress rules before deleting the rule itself. Enable for EMR."
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to security group"
+  type        = map(string)
+  default     = {}
+}
+
+##########
+# Ingress
+##########
+variable "ingress_rules" {
+  description = "List of ingress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_with_self" {
+  description = "List of ingress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_with_cidr_blocks" {
+  description = "List of ingress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_with_ipv6_cidr_blocks" {
+  description = "List of ingress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_with_source_security_group_id" {
+  description = "List of ingress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+###################
+# Computed Ingress
+###################
+variable "computed_ingress_rules" {
+  description = "List of computed ingress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "computed_ingress_with_self" {
+  description = "List of computed ingress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_with_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_with_ipv6_cidr_blocks" {
+  description = "List of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_with_source_security_group_id" {
+  description = "List of computed ingress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_ingress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "computed_ingress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "computed_ingress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  type        = list(string)
+  default     = []
+}
+
+###################################
+# Number of computed ingress rules
+###################################
+variable "number_of_computed_ingress_rules" {
+  description = "Number of computed ingress rules to create by name"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_self" {
+  description = "Number of computed ingress rules to create where 'self' is defined"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_ipv6_cidr_blocks" {
+  description = "Number of computed ingress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_with_source_security_group_id" {
+  description = "Number of computed ingress rules to create where 'source_security_group_id' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed ingress rules"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed ingress rules"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_ingress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed ingress rules"
+  type        = number
+  default     = 0
+}
+
+#########
+# Egress
+#########
+variable "egress_rules" {
+  description = "List of egress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "egress_with_self" {
+  description = "List of egress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_with_cidr_blocks" {
+  description = "List of egress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_with_ipv6_cidr_blocks" {
+  description = "List of egress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_with_source_security_group_id" {
+  description = "List of egress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all egress rules"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all egress rules"
+  type        = list(string)
+  default     = ["::/0"]
+}
+
+variable "egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all egress rules"
+  type        = list(string)
+  default     = []
+}
+
+##################
+# Computed Egress
+##################
+variable "computed_egress_rules" {
+  description = "List of computed egress rules to create by name"
+  type        = list(string)
+  default     = []
+}
+
+variable "computed_egress_with_self" {
+  description = "List of computed egress rules to create where 'self' is defined"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_with_cidr_blocks" {
+  description = "List of computed egress rules to create where 'cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_with_ipv6_cidr_blocks" {
+  description = "List of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_with_source_security_group_id" {
+  description = "List of computed egress rules to create where 'source_security_group_id' is used"
+  type        = list(map(string))
+  default     = []
+}
+
+variable "computed_egress_cidr_blocks" {
+  description = "List of IPv4 CIDR ranges to use on all computed egress rules"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "computed_egress_ipv6_cidr_blocks" {
+  description = "List of IPv6 CIDR ranges to use on all computed egress rules"
+  type        = list(string)
+  default     = ["::/0"]
+}
+
+variable "computed_egress_prefix_list_ids" {
+  description = "List of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  type        = list(string)
+  default     = []
+}
+
+##################################
+# Number of computed egress rules
+##################################
+variable "number_of_computed_egress_rules" {
+  description = "Number of computed egress rules to create by name"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_self" {
+  description = "Number of computed egress rules to create where 'self' is defined"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_ipv6_cidr_blocks" {
+  description = "Number of computed egress rules to create where 'ipv6_cidr_blocks' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_with_source_security_group_id" {
+  description = "Number of computed egress rules to create where 'source_security_group_id' is used"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_cidr_blocks" {
+  description = "Number of IPv4 CIDR ranges to use on all computed egress rules"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_ipv6_cidr_blocks" {
+  description = "Number of IPv6 CIDR ranges to use on all computed egress rules"
+  type        = number
+  default     = 0
+}
+
+variable "number_of_computed_egress_prefix_list_ids" {
+  description = "Number of prefix list IDs (for allowing access to VPC endpoints) to use on all computed egress rules"
+  type        = number
+  default     = 0
+}

--- a/modules/zabbix/versions.tf
+++ b/modules/zabbix/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.29"
+    }
+  }
+}

--- a/rules.tf
+++ b/rules.tf
@@ -177,6 +177,10 @@ variable "rules" {
     # WinRM
     winrm-http-tcp  = [5985, 5985, "tcp", "WinRM HTTP"]
     winrm-https-tcp = [5986, 5986, "tcp", "WinRM HTTPS"]
+    # Zabbix
+    zabbix-server = [10051, "tcp", "Zabbix Server"]
+    zabbix-proxy = [10051, "tcp", "Zabbix Proxy"]
+    zabbix-agent = [10050, "tcp", "Zabbix Agent"]
     # Zipkin
     zipkin-admin-tcp       = [9990, 9990, "tcp", "Zipkin Admin port collector"]
     zipkin-admin-query-tcp = [9901, 9901, "tcp", "Zipkin Admin port query"]
@@ -452,6 +456,11 @@ variable "auto_groups" {
     }
     winrm = {
       ingress_rules     = ["winrm-http-tcp", "winrm-https-tcp"]
+      ingress_with_self = ["all-all"]
+      egress_rules      = ["all-all"]
+    }
+    zabbix = {
+      ingress_rules     = ["zabbix-server", "zabbix-proxy", "zabbix-agent"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }


### PR DESCRIPTION
## Description
This adds the needed ports for Zabbix server, proxy and agent

## Motivation and Context
We are trying to fully automate the install of Zabbix infrastructure and this will make it easier to open the needed ports

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
