### PR TITLE
fix: All- port rules to use 0, 0 for smooth import

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -205,11 +205,11 @@ variable "rules" {
     zookeeper-3888-tcp     = [3888, 3888, "tcp", "Zookeeper"]
     zookeeper-jmx-tcp      = [7199, 7199, "tcp", "JMX"]
     # Open all ports & protocols
-    all-all       = [-1, -1, "-1", "All protocols"]
+    all-all       = [0, 0, "-1", "All protocols"]
     all-tcp       = [0, 65535, "tcp", "All TCP ports"]
     all-udp       = [0, 65535, "udp", "All UDP ports"]
-    all-icmp      = [-1, -1, "icmp", "All IPV4 ICMP"]
-    all-ipv6-icmp = [-1, -1, 58, "All IPV6 ICMP"]
+    all-icmp      = [0, 0, "icmp", "All IPV4 ICMP"]
+    all-ipv6-icmp = [0, 0, 58, "All IPV6 ICMP"]
     # This is a fallback rule to pass to lookup() as default. It does not open anything, because it should never be used.
     _ = ["", "", ""]
   }


### PR DESCRIPTION
## Description
This update is supposed to both make it easier to import your security group rules in another terraform state, as well as align with documentation found here regarding how to specify an allow all protocols and ports etc. 
: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule#from_port

## Motivation and Context
I wanted to move module from one terraform state to another, but faced some challenges, due to from_port and to_port using the value -1, and not as expected 0.

This means -1 it stored in state file for those two properties, however this seems to be problematic if you want to import your generated security group rules in another state file, as -1 is not allowed with terraform import, as well as "-1" (string) is only mentioned when specifying protocol, not for ports, there the terraform documentation leaves you with the impression you're supposed to use protocol = "-1" from_port = 0 to_port = 0 in the case of allowing everything.

## Breaking Changes
Not that I'm aware of, but will replace rules, possibly blocking traffic shortly

## How Has This Been Tested?
To sanity check this, I tried to create a security group from console, where I verified from_port & to_port got the value 0 and no drifts to deal with after terraform import. In comparison this module will have the value -1 for those to properties when using eg. the all-all rule.

Import was done with following commands, it is the last import that causes terraform to want to replace rules due to the lack of possibility to use -1 or all as port values:
```
terraform import 'module.aws_rds_aurora_security_group.module.sg.aws_security_group.this_name_prefix[0]' sg-0d9c5a4d4ad123456
terraform import 'module.aws_rds_aurora_security_group.module.sg.aws_security_group_rule.ingress_with_self[0]' sg-0d9c5a4d4ad123456_ingress_all_0_0_self
terraform import 'module.aws_rds_aurora_security_group.module.sg.aws_security_group_rule.ingress_rules[0]' sg-0d9c5a4d4ad123456_ingress_tcp_5432_5432_10.0.0.0/16
terraform import 'module.aws_rds_aurora_security_group.module.sg.aws_security_group_rule.egress_rules[0]' sg-0d9c5a4d4ad123456_egress_all_0_0_0.0.0.0/0
```
terraform plan after import of security group and rules with following commands:
```
  # module.aws_rds_aurora_security_group.module.sg.aws_security_group_rule.egress_rules[0] must be replaced
-/+ resource "aws_security_group_rule" "egress_rules" {
      ~ from_port                = 0 -> -1
      ~ id                       = "sgrule-2462123456" -> (known after apply)
      ~ ipv6_cidr_blocks         = [ # forces replacement
          + "::/0",
        ]
      + source_security_group_id = (known after apply)
      ~ to_port                  = 0 -> -1
        # (7 unchanged attributes hidden)
    }
```

### Steps to reproduce:
Create a security group in vpc like this
```
module "aws_rds_aurora_security_group" {
  source  = "terraform-aws-modules/security-group/aws//modules/postgresql"
  version = "~> 4.0"

  name        = "aurora-postgresql-sg"
  description = "Security group with postgreSQL ports open"
  vpc_id      = module.aws_vpc.vpc_id

  ingress_cidr_blocks = module.aws_vpc.private_subnets_cidr_blocks
}
```

The following is the egress rule as generated by the module :
```
  + resource "aws_security_group_rule" "egress_rules" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "All protocols"
      + from_port                = -1
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = [
          + "::/0",
        ]
      + prefix_list_ids          = []
      + protocol                 = "-1"
      + security_group_id        = "sg-0d9c5a4d4ad123456"
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = -1
      + type                     = "egress"
    }
```
