### PR TITLE
fix: Corrected transposed number in smtps rule

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -161,7 +161,7 @@ variable "rules" {
     smtp-submission-587-tcp  = [587, 587, "tcp", "SMTP Submission"]
     smtp-submission-2587-tcp = [2587, 2587, "tcp", "SMTP Submission"]
     smtps-465-tcp            = [465, 465, "tcp", "SMTPS"]
-    smtps-2456-tcp           = [2465, 2465, "tcp", "SMTPS"]
+    smtps-2465-tcp           = [2465, 2465, "tcp", "SMTPS"]
     # Solr
     solr-tcp = [8983, 8987, "tcp", "Solr"]
     # Splunk


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
corrected transposed number
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
to make the smpts submodule work
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
no
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
