### PR TITLE
fix: Create simple ingress rules in SG only if CIDR or Prefix ID List provided

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -39,6 +39,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_ipv4_ipv6_example"></a> [ipv4\_ipv6\_example](#module\_ipv4\_ipv6\_example) | ../../ | n/a |
 | <a name="module_main_sg"></a> [main\_sg](#module\_main\_sg) | ../../ | n/a |
 | <a name="module_only_rules"></a> [only\_rules](#module\_only\_rules) | ../../ | n/a |
+| <a name="module_only_rules_with_auto_ingress_rules"></a> [only\_rules\_with\_auto\_ingress\_rules](#module\_only\_rules\_with\_auto\_ingress\_rules) | ../../ | n/a |
 | <a name="module_prefix_list"></a> [prefix\_list](#module\_prefix\_list) | ../../ | n/a |
 | <a name="module_prefix_list_sg"></a> [prefix\_list\_sg](#module\_prefix\_list\_sg) | ../../ | n/a |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -401,6 +401,24 @@ module "only_rules" {
   ]
 }
 
+###################################################
+# Only security group rules with auto ingress rules
+###################################################
+module "only_rules_with_auto_ingress_rules" {
+  source = "../../"
+
+  create_sg         = false
+  security_group_id = module.complete_sg.security_group_id
+  ingress_rules     = ["redis-tcp"]
+  ingress_with_source_security_group_id = [
+    {
+      description              = "http from service one"
+      rule                     = "redis-tcp"
+      source_security_group_id = data.aws_security_group.default.id
+    },
+  ]
+}
+
 ###################################
 # Security group with prefix lists
 ###################################

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   create = var.create && var.putin_khuylo
 
   this_sg_id                 = var.create_sg ? concat(aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id, [""])[0] : var.security_group_id
-  create_simple_ingress_rule = concat(var.ingress_cidr_blocks, var.ingress_ipv6_cidr_blocks, ingress_prefix_list_ids) != [""]
+  create_simple_ingress_rule = concat(var.ingress_cidr_blocks, var.ingress_ipv6_cidr_blocks, var.ingress_prefix_list_ids) != [""]
 }
 
 ##########################

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,8 @@
 locals {
   create = var.create && var.putin_khuylo
 
-  this_sg_id = var.create_sg ? concat(aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id, [""])[0] : var.security_group_id
+  this_sg_id                 = var.create_sg ? concat(aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id, [""])[0] : var.security_group_id
+  create_simple_ingress_rule = concat(var.ingress_cidr_blocks, var.ingress_ipv6_cidr_blocks, ingress_prefix_list_ids) != [""]
 }
 
 ##########################
@@ -64,7 +65,7 @@ resource "aws_security_group" "this_name_prefix" {
 ###################################
 # Security group rules with "cidr_blocks" and it uses list of rules names
 resource "aws_security_group_rule" "ingress_rules" {
-  count = local.create ? length(var.ingress_rules) : 0
+  count = local.create && local.create_simple_ingress_rule ? length(var.ingress_rules) : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   create = var.create && var.putin_khuylo
 
   this_sg_id                 = var.create_sg ? concat(aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id, [""])[0] : var.security_group_id
-  create_simple_ingress_rule = concat(var.ingress_cidr_blocks, var.ingress_ipv6_cidr_blocks, var.ingress_prefix_list_ids) != [""]
+  create_simple_ingress_rule = length(concat(var.ingress_cidr_blocks, var.ingress_ipv6_cidr_blocks, var.ingress_prefix_list_ids)) != 0
 }
 
 ##########################


### PR DESCRIPTION
## Description
An ingress rule requires CIDR, group ID or an ID Prefix list. In the console, creation will fail with error `CIDR block, a security group ID or a prefix list has to be specified.` while trying to create an ingress rule without any of these. The terraform resource documentation also says the same `Although cidr_blocks, ipv6_cidr_blocks, prefix_list_ids, and source_security_group_id are all marked as optional, you must provide one of them in order to configure the source of the traffic.` The API probably fails in a funny way that terraform doesn't capture any error and it creates a zombie resource in the state.

In this module, there is an [ingress rule](https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/43974e94067251ee464018288aa44862d0adba22/main.tf#L65) getting created based on the inputs. If you want to create rules based on source security id only and auto ingress rules (say for redis), this still tries to create an ingress rule based on cidr/prefix_list_ids. Since AWS doesn't allow this, a zombie resource is created in the state. Now every time you run a plan against this state, it tries to update the description. This is not a nice experience in different ways.

This PR will fix the issue by making this ingress rule creation conditional based on if there is any of CIDR/ID Prefix list available as input. So there won't be a resource that gets updated with every plan/apply.

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/296

## Breaking Changes
No breaking changes. This change doesn't impact any real resource.
After this change, running a plan will show the below change. But it seems this is a zombie resource that exists only in the state and it doesn't exist as a rule under the mentioned security group.  The state doesn't have a group rule id (security_group_rule_id), just as shown in the [issue](https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/296).
```
  # module.only_rules_with_auto_ingress_rules.aws_security_group_rule.ingress_rules[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_security_group_rule" "ingress_rules" {
      - cidr_blocks       = [] -> null
      - from_port         = 6379 -> null
      - id                = "sgrule-1244344090" -> null
      - ipv6_cidr_blocks  = [] -> null
      - prefix_list_ids   = [] -> null
      - protocol          = "tcp" -> null
      - security_group_id = "sg-0ef4cb41c216f212e" -> null
      - self              = false -> null
      - to_port           = 6379 -> null
      - type              = "ingress" -> null
    }
```

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- Added new test
- Ran the test (plan) without making the desired changes
- The new test resource created below plan
```
  # module.only_rules_with_auto_ingress_rules.aws_security_group_rule.ingress_rules[0] will be created
  + resource "aws_security_group_rule" "ingress_rules" {
      + cidr_blocks              = []
      + description              = "Redis"
      + from_port                = 6379
      + id                       = (known after apply)
      + ipv6_cidr_blocks         = []
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 6379
      + type                     = "ingress"
    }

  # module.only_rules_with_auto_ingress_rules.aws_security_group_rule.ingress_with_source_security_group_id[0] will be created
  + resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      + description              = "http from service one"
      + from_port                = 6379
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-0823a2815efbe3be1"
      + to_port                  = 6379
      + type                     = "ingress"
    }
```
- Incorporated the changes
- Ran the test (plan)
- The new test created below plan
```
  # module.only_rules_with_auto_ingress_rules.aws_security_group_rule.ingress_with_source_security_group_id[0] will be created
  + resource "aws_security_group_rule" "ingress_with_source_security_group_id" {
      + description              = "http from service one"
      + from_port                = 6379
      + id                       = (known after apply)
      + prefix_list_ids          = []
      + protocol                 = "tcp"
      + security_group_id        = (known after apply)
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = "sg-0823a2815efbe3be1"
      + to_port                  = 6379
      + type                     = "ingress"
    }
```
- The `ingress-rules` resource is not getting created as desired
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- Ran the existing test (plan/apply) without making the desired changes
- Incorporated the changes
- Run the plan and got `No changes. Your infrastructure matches the configuration.`
- [x] I have executed `pre-commit run -a` on my pull request
```
pre-commit run -a                   
[INFO] Initializing environment for https://github.com/antonbabenko/pre-commit-terraform.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
Terraform fmt............................................................Passed
Terraform validate.......................................................Passed
Terraform docs...........................................................Failed
- hook id: terraform_docs
- files were modified by this hook
check for merge conflicts................................................Passed
fix end of files.........................................................Passed
```
