### PR TITLE
chore: Update list item access syntax to use square brackets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@
 locals {
   create = var.create && var.putin_khuylo
 
-  this_sg_id = var.create_sg ? concat(aws_security_group.this.*.id, aws_security_group.this_name_prefix.*.id, [""])[0] : var.security_group_id
+  this_sg_id = var.create_sg ? concat(aws_security_group.this[*].id, aws_security_group.this_name_prefix[*].id, [""])[0] : var.security_group_id
 }
 
 ##########################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixed TFLint warnings related to the `terraform_deprecated_index` rule.
Updated the list index access syntax from using the splat operator `.*` to square brackets `[*]` to adhere to newer Terraform standards and resolve the TFLint warnings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When calling this module directly via the terraform.source in terragrunt.hcl, TFLint warnings are triggered. 
Disabling the rule for each directory using .tflint.hcl is cumbersome.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

None
## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
