### PR TITLE
feat: Allow the creation of prefix-list rules, passing in unique prefix list IDs on a per rule basis

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -437,7 +437,12 @@ resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = lookup(
+    var.ingress_with_prefix_list_ids[count.index], "include_base_prefix_list_ids", true
+    ) ? concat(
+    var.ingress_prefix_list_ids, lookup(var.ingress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+  ) : lookup(var.ingress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+
   description = lookup(
     var.ingress_with_prefix_list_ids[count.index],
     "description",
@@ -468,7 +473,12 @@ resource "aws_security_group_rule" "computed_ingress_with_prefix_list_ids" {
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  prefix_list_ids = var.ingress_prefix_list_ids
+  prefix_list_ids = lookup(
+    var.ingress_with_prefix_list_ids[count.index], "include_base_prefix_list_ids", true
+    ) ? concat(
+    var.ingress_prefix_list_ids, lookup(var.ingress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+  ) : lookup(var.ingress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+
   description = lookup(
     var.ingress_with_prefix_list_ids[count.index],
     "description",
@@ -875,7 +885,12 @@ resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  prefix_list_ids = var.egress_prefix_list_ids
+  prefix_list_ids = lookup(
+    var.egress_with_prefix_list_ids[count.index], "include_base_prefix_list_ids", true
+    ) ? concat(
+    var.egress_prefix_list_ids, lookup(var.egress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+  ) : lookup(var.egress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+
   description = lookup(
     var.egress_with_prefix_list_ids[count.index],
     "description",
@@ -911,15 +926,19 @@ resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
   )
 }
 
-# Computed - Security group rules with "source_security_group_id", but without "cidr_blocks", "self" or "source_security_group_id"
+# Computed - Security group rules with "egress_prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "computed_egress_with_prefix_list_ids" {
   count = var.create ? var.number_of_computed_egress_with_prefix_list_ids : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  source_security_group_id = var.computed_egress_with_prefix_list_ids[count.index]["source_security_group_id"]
-  prefix_list_ids          = var.egress_prefix_list_ids
+  prefix_list_ids = lookup(
+    var.egress_with_prefix_list_ids[count.index], "include_base_prefix_list_ids", true
+    ) ? concat(
+    var.egress_prefix_list_ids, lookup(var.egress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+  ) : lookup(var.egress_with_prefix_list_ids[count.index]["prefix_list_ids"], [])
+
   description = lookup(
     var.computed_egress_with_prefix_list_ids[count.index],
     "description",


### PR DESCRIPTION
## Description
This PR is meant to address the complaints in this [open issue](https://github.com/terraform-aws-modules/terraform-aws-security-group/issues/312)

## Motivation and Context
The existing codebase does not allow the creation of prefix-list based rules, where you can pass in prefix list IDs on a per-rule basis.  You can only assign prefix list IDs at the module level, which is not particularly helpful.

## Breaking Changes
Default values have been implemented, with the intention of not introducing any breaking changes

## How Has This Been Tested?
I can start testing with examples, but I'd like to wait and see if this PR gets shut down before I put any more effort into it.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
