### PR TITLE
fix: Remove `prefix_list_ids` attribute from `*_with_self` resouces

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -374,8 +374,7 @@ resource "aws_security_group_rule" "ingress_with_self" {
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  self            = lookup(var.ingress_with_self[count.index], "self", true)
-  prefix_list_ids = var.ingress_prefix_list_ids
+  self = lookup(var.ingress_with_self[count.index], "self", true)
   description = lookup(
     var.ingress_with_self[count.index],
     "description",
@@ -406,8 +405,7 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
   security_group_id = local.this_sg_id
   type              = "ingress"
 
-  self            = lookup(var.computed_ingress_with_self[count.index], "self", true)
-  prefix_list_ids = var.ingress_prefix_list_ids
+  self = lookup(var.computed_ingress_with_self[count.index], "self", true)
   description = lookup(
     var.computed_ingress_with_self[count.index],
     "description",
@@ -811,8 +809,7 @@ resource "aws_security_group_rule" "egress_with_self" {
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  self            = lookup(var.egress_with_self[count.index], "self", true)
-  prefix_list_ids = var.egress_prefix_list_ids
+  self = lookup(var.egress_with_self[count.index], "self", true)
   description = lookup(
     var.egress_with_self[count.index],
     "description",
@@ -843,8 +840,7 @@ resource "aws_security_group_rule" "computed_egress_with_self" {
   security_group_id = local.this_sg_id
   type              = "egress"
 
-  self            = lookup(var.computed_egress_with_self[count.index], "self", true)
-  prefix_list_ids = var.egress_prefix_list_ids
+  self = lookup(var.computed_egress_with_self[count.index], "self", true)
   description = lookup(
     var.computed_egress_with_self[count.index],
     "description",


### PR DESCRIPTION
## Description

`aws_security_group_rule` with both `self = true` and non-empty `prefix_list_ids` generates multiple (# of self + # of prefix_list_ids) rules for self and each prefix_list_ids, for example,

```terraform
resource "aws_security_group_rule" "ingress_with_self" {
  security_group_id = local.this_sg_id
  type              = "ingress"

  self            = true
  prefix_list_ids = ["id1", "id2"]
  description     = "sample"

  from_port = -1
  to_port   = -1
  protocol  = "-1"
}
```

then we get the rules **not only** allow all-all from self SG, **but also**  allow all-all from prefix-list `id1` and allow all-all from prefix-list `id2`. I think this is unexpected result, `ingress_with_self` itself should only add rule to allow self SG, so remove `prefix_list_ids` attribute from `*_with_self` resouces.

## Motivation and Context

Described as above.

## Breaking Changes

This change avoid creating SG rules allow all-all from each prefix-list, this is breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
