### PR TITLE
fix: Change plan order in case of used SG rename

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,10 @@ resource "aws_security_group" "this" {
     var.tags,
   )
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   timeouts {
     create = var.create_timeout
     delete = var.delete_timeout


### PR DESCRIPTION
## Description
If a SG is created and used by another resource, and a rename of the SG is required, this is only possible with recreating the using resource as well or by adding this lifecycle rule to the SG.

## Motivation and Context
Described above.

## Breaking Changes
None.

## How Has This Been Tested?
Tested by locally updating the module and deploying.

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
