### PR TITLE
fix: Consistent handling of cidr_blocks in *_with_ipv6_cidr_blocks helpers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -293,7 +293,11 @@ resource "aws_security_group_rule" "ingress_with_ipv6_cidr_blocks" {
     lookup(
       var.ingress_with_ipv6_cidr_blocks[count.index],
       "ipv6_cidr_blocks",
-      join(",", var.ingress_ipv6_cidr_blocks),
+      lookup(
+        var.ingress_with_ipv6_cidr_blocks[count.index],
+        "cidr_blocks",
+        join(",", var.ingress_ipv6_cidr_blocks),
+      ),
     ),
   ))
   prefix_list_ids = var.ingress_prefix_list_ids
@@ -332,7 +336,11 @@ resource "aws_security_group_rule" "computed_ingress_with_ipv6_cidr_blocks" {
     lookup(
       var.computed_ingress_with_ipv6_cidr_blocks[count.index],
       "ipv6_cidr_blocks",
-      join(",", var.ingress_ipv6_cidr_blocks),
+      lookup(
+        var.computed_ingress_with_ipv6_cidr_blocks[count.index],
+        "cidr_blocks",
+        join(",", var.ingress_ipv6_cidr_blocks),
+      ),
     ),
   ))
   prefix_list_ids = var.ingress_prefix_list_ids
@@ -754,7 +762,11 @@ resource "aws_security_group_rule" "egress_with_ipv6_cidr_blocks" {
     lookup(
       var.egress_with_ipv6_cidr_blocks[count.index],
       "ipv6_cidr_blocks",
-      join(",", var.egress_ipv6_cidr_blocks),
+      lookup(
+        var.egress_with_ipv6_cidr_blocks[count.index],
+        "cidr_blocks",
+        join(",", var.egress_ipv6_cidr_blocks),
+      ),
     ),
   ))
   prefix_list_ids = var.egress_prefix_list_ids
@@ -793,7 +805,11 @@ resource "aws_security_group_rule" "computed_egress_with_ipv6_cidr_blocks" {
     lookup(
       var.computed_egress_with_ipv6_cidr_blocks[count.index],
       "ipv6_cidr_blocks",
-      join(",", var.egress_ipv6_cidr_blocks),
+      lookup(
+        var.computed_egress_with_ipv6_cidr_blocks[count.index],
+        "cidr_blocks",
+        join(",", var.egress_ipv6_cidr_blocks),
+      ),
     ),
   ))
   prefix_list_ids = var.egress_prefix_list_ids


### PR DESCRIPTION
## Description

Fixes #352

When a user accidentally specifies `cidr_blocks` instead of `ipv6_cidr_blocks` in the `*_with_ipv6_cidr_blocks` helper variables, the behavior was inconsistent between ingress and egress:

### Before this fix:
- **Ingress**: `ipv6_cidr_blocks = []` (silent no-op, rule does nothing)
- **Egress**: `ipv6_cidr_blocks = ["::/0"]` (appears to work, but only because `var.egress_ipv6_cidr_blocks` defaults to `["::/0"]`)

Neither actually reads the user's `cidr_blocks` value - the egress case only works by coincidence of the default.

### After this fix:
Both ingress and egress (and their computed variants) now fall back to looking up the `cidr_blocks` key when `ipv6_cidr_blocks` is not found, before falling back to the module-level default. This makes the behavior consistent and prevents silent no-op rules.

## Changes

- Added nested `lookup(..., "cidr_blocks", ...)` as fallback in the `ipv6_cidr_blocks` attribute for:
  - `ingress_with_ipv6_cidr_blocks`
  - `computed_ingress_with_ipv6_cidr_blocks`
  - `egress_with_ipv6_cidr_blocks`
  - `computed_egress_with_ipv6_cidr_blocks`