### PR TITLE
chore: Change count condition from var.create to local.create

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -436,7 +436,7 @@ resource "aws_security_group_rule" "computed_ingress_with_self" {
 }
 # Security group rules with "prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
-  count = var.create ? length(var.ingress_with_prefix_list_ids) : 0
+  count = local.create ? length(var.ingress_with_prefix_list_ids) : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -477,7 +477,7 @@ resource "aws_security_group_rule" "ingress_with_prefix_list_ids" {
 
 # Computed - Security group rules with "prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "computed_ingress_with_prefix_list_ids" {
-  count = var.create ? var.number_of_computed_ingress_with_prefix_list_ids : 0
+  count = local.create ? var.number_of_computed_ingress_with_prefix_list_ids : 0
 
   security_group_id = local.this_sg_id
   type              = "ingress"
@@ -898,7 +898,7 @@ resource "aws_security_group_rule" "computed_egress_with_self" {
 
 # Security group rules with "egress_prefix_list_ids", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
-  count = var.create ? length(var.egress_with_prefix_list_ids) : 0
+  count = local.create ? length(var.egress_with_prefix_list_ids) : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"
@@ -951,7 +951,7 @@ resource "aws_security_group_rule" "egress_with_prefix_list_ids" {
 
 # Computed - Security group rules with "source_security_group_id", but without "cidr_blocks", "self" or "source_security_group_id"
 resource "aws_security_group_rule" "computed_egress_with_prefix_list_ids" {
-  count = var.create ? var.number_of_computed_egress_with_prefix_list_ids : 0
+  count = local.create ? var.number_of_computed_egress_with_prefix_list_ids : 0
 
   security_group_id = local.this_sg_id
   type              = "egress"


### PR DESCRIPTION

## Description
Replace `var.create` with `local.create` on lines 439, 480, 901, and 954 to bring these resources in line with their siblings.

## Motivation and Context
local.create is defined as var.create && var.putin_khuylo (main.tf:5) and is used by all 22 other aws_security_group_rule resources in this file. The four prefix-list resources were the only ones still keyed on var.create alone, so they were created even when putin_khuylo = false — inconsistent with the rest of the module and bypassing the intended toggle.

## Breaking Changes
Effectively none. `putin_khuylo` defaults to true, so for any user on the default the four count expressions evaluate identically before and after this change `(var.create && true == var.create)`. The only user-visible behaviour change is for someone who explicitly set `putin_khuylo = false` and uses any of the four `*_with_prefix_list_ids rule sets` — on next apply those rules will be destroyed. That is the documented intent of the toggle (it gates every other rule resource in the module already), so this brings the four outliers in line with the rest.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [X] I have executed `pre-commit run -a` on my pull request
