### PR TITLE
chore: Change carbon-gui-udp to carbon-gui-tcp

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -20,7 +20,7 @@ variable "rules" {
     carbon-pickle-tcp  = [2013, 2013, "tcp", "Carbon pickle"]
     carbon-pickle-udp  = [2013, 2013, "udp", "Carbon pickle"]
     carbon-admin-tcp   = [2004, 2004, "tcp", "Carbon admin"]
-    carbon-gui-udp     = [8081, 8081, "tcp", "Carbon GUI"]
+    carbon-gui-tcp     = [8081, 8081, "tcp", "Carbon GUI"]
     # Cassandra
     cassandra-clients-tcp        = [9042, 9042, "tcp", "Cassandra clients"]
     cassandra-thrift-clients-tcp = [9160, 9160, "tcp", "Cassandra Thrift clients"]

--- a/rules.tf
+++ b/rules.tf
@@ -238,7 +238,7 @@ variable "auto_groups" {
       egress_rules      = ["all-all"]
     }
     carbon-relay-ng = {
-      ingress_rules     = ["carbon-line-in-tcp", "carbon-line-in-udp", "carbon-pickle-tcp", "carbon-pickle-udp", "carbon-gui-udp"]
+      ingress_rules     = ["carbon-line-in-tcp", "carbon-line-in-udp", "carbon-pickle-tcp", "carbon-pickle-udp", "carbon-gui-tcp"]
       ingress_with_self = ["all-all"]
       egress_rules      = ["all-all"]
     }


### PR DESCRIPTION
## Description
Rename the predefined rule key carbon-gui-udp to carbon-gui-tcp in rules.tf. The protocol value stays "tcp"; only the map key changes.

## Motivation and Context
Every other -udp-suffixed entry in this block has a -tcp sibling (carbon-line-in-tcp/-udp, carbon-pickle-tcp/-udp). carbon-gui-udp was the only orphan -udp entry.
Renaming the key keeps the actual rule semantics (TCP/8081) intact and removes the misleading name.
No issue linked.

## Breaking Changes
Yes — any module consumer that lists "carbon-gui-udp" in ingress_rules / egress_rules will fail with a var.rules key lookup error on next plan. They must rename their reference to "carbon-gui-tcp". No infrastructure is destroyed/recreated; only the lookup key string changes. Recommend calling this out in the changelog as a name-only breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the examples/* to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided examples/* projects
- [X] I have executed pre-commit run -a on my pull request
