### PR TITLE
feat(tags): Autogen Name tag, if var.name is set. analogous to ec2-instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,8 @@ resource "aws_security_group" "this" {
   vpc_id                 = var.vpc_id
 
   tags = merge(
-    var.tags,
-    var.name != "" ? { "Name" = var.name } : {}
+    var.name != "" ? { "Name" = var.name } : {},
+    var.tags
   )
 
   dynamic "timeouts" {

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,10 @@ resource "aws_security_group" "this" {
   revoke_rules_on_delete = var.revoke_rules_on_delete
   vpc_id                 = var.vpc_id
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    var.name != "" ? { "Name" = var.name } : {}
+  )
 
   dynamic "timeouts" {
     for_each = var.timeouts != null ? [var.timeouts] : []


### PR DESCRIPTION
## Description
simple change to add var.name to tags, like ec2-instance module does already.
i reversed the merge() order compared to ec2-instance, to allow a custom tags.Name to overwrite the automatic default.

## Motivation and Context
displays clean name in AWS web console.

## Breaking Changes
none